### PR TITLE
Replace old repo URL with GitHub repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ framework for trading.
 [crates-url]: https://crates.io/crates/barter
 
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-[mit-url]: https://gitlab.com/open-source-keir/financial-modelling/trading/barter-rs/-/blob/main/LICENCE
+[mit-url]: https://github.com/barter-rs/barter-rs/blob/develop/LICENSE
 
-[actions-badge]: https://gitlab.com/open-source-keir/financial-modelling/trading/barter-rs/badges/-/blob/main/pipeline.svg
-[actions-url]: https://gitlab.com/open-source-keir/financial-modelling/trading/barter-rs/-/commits/master
+[actions-badge]: https://github.com/barter-rs/barter-rs/actions/workflows/ci.yml/badge.svg?branch=main
+[actions-url]: https://github.com/barter-rs/barter-rs/blob/main/.github/workflows/ci.yml
 
 [discord-badge]: https://img.shields.io/discord/910237311332151317.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/wE7RqhnQMV
@@ -184,7 +184,7 @@ as providing an example multi-timeframe Strategy using the utilities.
 ## Licence
 This project is licensed under the [MIT license].
 
-[MIT license]: https://gitlab.com/open-source-keir/financial-modelling/trading/barter-rs/-/blob/master/LICENSE
+[MIT license]: https://github.com/barter-rs/barter-rs/blob/develop/LICENSE
 
 ### Contribution
 Unless you explicitly state otherwise, any contribution intentionally submitted

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! * **Engine**: Multi-threaded trading Engine capable of trading with an arbitrary number of Trader market pairs. Each
 //! contained Trader instance operates on its own thread.
 //!
-//! [`Barter`]: https://gitlab.com/open-source-keir/financial-modelling/trading/barter-rs
+//! [`Barter`]: https://github.com/barter-rs/barter-rs
 //! [`Barter-Data`]: https://crates.io/crates/barter-data
 //! [`Readme`]: https://crates.io/crates/barter
 //!


### PR DESCRIPTION
# Replace old repo URL with GitHub repo URL


## Summary

Pretty much self-explanatory.


## Description

Replace the old project repo URL with the _GitHub_ repo URL in the following files:
* `lib.rs`
* `README.md`
  * update MIT license URL
  * update CI pipeline badge