### PR TITLE
Chore: Update Barter Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Just A Stream <93921983+just-a-stream@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["accessibility", "simulation"]
 
 [dependencies]
 # Barter Ecosystem
-barter-data = "0.5.10"
-barter-integration = "0.4.0"
+barter-data = "0.6.5"
+barter-integration = "0.5.1"
 
 # Logging
 tracing = "0.1.36"

--- a/examples/engine_with_historic_candles.rs
+++ b/examples/engine_with_historic_candles.rs
@@ -16,7 +16,8 @@ use barter::{
     },
     strategy::example::{Config as StrategyConfig, RSIStrategy},
 };
-use barter_data::model::{Candle, DataKind, MarketEvent};
+use barter_data::event::{DataKind, MarketEvent};
+use barter_data::subscription::candle::Candle;
 use barter_integration::model::{Exchange, Instrument, InstrumentKind, Market};
 use chrono::Utc;
 use parking_lot::Mutex;
@@ -110,7 +111,7 @@ async fn main() {
     engine.run().await;
 }
 
-fn load_json_market_event_candles() -> Vec<MarketEvent> {
+fn load_json_market_event_candles() -> Vec<MarketEvent<DataKind>> {
     let candles =
         fs::read_to_string("barter-rs/examples/data/candles_1h.json").expect("failed to read file");
 
@@ -120,7 +121,7 @@ fn load_json_market_event_candles() -> Vec<MarketEvent> {
     candles
         .into_iter()
         .map(|candle| MarketEvent {
-            exchange_time: candle.end_time,
+            exchange_time: candle.close_time,
             received_time: Utc::now(),
             exchange: Exchange::from("binance"),
             instrument: Instrument::from(("btc", "usdt", InstrumentKind::Spot)),

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -14,5 +14,5 @@ pub enum DataError {
     Socket(#[from] SocketError),
 
     #[error("Barter-Data: {0}")]
-    Data(#[from] barter_data::error::DataError)
+    Data(#[from] barter_data::error::DataError),
 }

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -12,4 +12,7 @@ pub enum DataError {
 
     #[error("Socket: {0}")]
     Socket(#[from] SocketError),
+
+    #[error("Barter-Data: {0}")]
+    Data(#[from] barter_data::error::DataError)
 }

--- a/src/data/historical.rs
+++ b/src/data/historical.rs
@@ -1,33 +1,37 @@
 use crate::data::{Feed, MarketGenerator};
-use barter_data::model::MarketEvent;
 
-/// Historical [`Feed`] of [`MarketEvent`]s.
+/// Historical [`Feed`] of market events.
 #[derive(Debug)]
-pub struct MarketFeed<I>
+pub struct MarketFeed<Iter, Event>
 where
-    I: Iterator<Item = MarketEvent>,
+    Iter: Iterator<Item = Event>,
 {
-    pub market_iterator: I,
+    pub market_iterator: Iter,
 }
 
-impl<I> MarketGenerator for MarketFeed<I>
+impl<Iter, Event> MarketGenerator<Event> for MarketFeed<Iter, Event>
 where
-    I: Iterator<Item = MarketEvent>,
+    Iter: Iterator<Item = Event>,
 {
-    fn generate(&mut self) -> Feed<MarketEvent> {
+    fn next(&mut self) -> Feed<Event> {
         self.market_iterator
             .next()
             .map_or(Feed::Finished, Feed::Next)
     }
 }
 
-impl<I> MarketFeed<I>
+impl<Iter, Event> MarketFeed<Iter, Event>
 where
-    I: Iterator<Item = MarketEvent>,
+    Iter: Iterator<Item = Event>,
 {
-    /// Construct a historical [`MarketFeed`] that yields [`MarketEvent`]s from the `Iterator`
+    /// Construct a historical [`MarketFeed`] that yields market events from the `IntoIterator`
     /// provided.
-    pub fn new(market_iterator: I) -> Self {
-        Self { market_iterator }
+    pub fn new<IntoIter>(market_iterator: IntoIter) -> Self
+    where
+        IntoIter: IntoIterator<Item = Event, IntoIter = Iter>,
+    {
+        Self {
+            market_iterator: market_iterator.into_iter(),
+        }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,4 +1,3 @@
-use barter_data::model::MarketEvent;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -11,10 +10,10 @@ pub mod live;
 /// Historical [`MarketEvent`] feed for backtesting.
 pub mod historical;
 
-/// Generates the latest [`MarketEvent`]. Acts as the system heartbeat.
-pub trait MarketGenerator {
-    /// Return the latest [`MarketEvent`].
-    fn generate(&mut self) -> Feed<MarketEvent>;
+/// Generates the next `Event`. Acts as the system heartbeat.
+pub trait MarketGenerator<Event> {
+    /// Return the next market `Event`.
+    fn next(&mut self) -> Feed<Event>;
 }
 
 /// Communicates the state of the [`Feed`] as well as the next event.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     statistic::summary::{PositionSummariser, TableBuilder},
     strategy::SignalGenerator,
 };
+use barter_data::event::{DataKind, MarketEvent};
 use barter_integration::model::{Market, MarketId};
 use parking_lot::Mutex;
 use prettytable::Table;
@@ -53,7 +54,7 @@ where
     EventTx: MessageTransmitter<Event> + Send,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater + Send,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {
@@ -93,7 +94,7 @@ where
         + FillUpdater
         + Send
         + 'static,
-    Data: MarketGenerator + Send + 'static,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send + 'static,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {
@@ -127,7 +128,7 @@ where
         + FillUpdater
         + Send
         + 'static,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send + 'static,
     Execution: ExecutionClient + Send + 'static,
 {
@@ -362,7 +363,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater + Send,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {
@@ -385,7 +386,7 @@ where
         + OrderGenerator
         + FillUpdater
         + Send,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {

--- a/src/engine/trader.rs
+++ b/src/engine/trader.rs
@@ -6,6 +6,7 @@ use crate::{
     portfolio::{FillUpdater, MarketUpdater, OrderGenerator},
     strategy::{SignalForceExit, SignalGenerator},
 };
+use barter_data::event::{DataKind, MarketEvent};
 use barter_integration::model::Market;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -21,7 +22,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater,
-    Data: MarketGenerator,
+    Data: MarketGenerator<MarketEvent<DataKind>>,
     Strategy: SignalGenerator,
     Execution: ExecutionClient,
 {
@@ -57,7 +58,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {
@@ -91,7 +92,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {
@@ -141,7 +142,7 @@ where
             }
 
             // If the Feed<MarketEvent> yields, populate event_q with the next MarketEvent
-            match self.data.generate() {
+            match self.data.next() {
                 Feed::Next(market) => {
                     self.event_tx.send(Event::Market(market.clone()));
                     self.event_q.push_back(Event::Market(market));
@@ -268,7 +269,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater,
-    Data: MarketGenerator,
+    Data: MarketGenerator<MarketEvent<DataKind>>,
     Strategy: SignalGenerator,
     Execution: ExecutionClient,
 {
@@ -289,7 +290,7 @@ where
     EventTx: MessageTransmitter<Event>,
     Statistic: Serialize + Send,
     Portfolio: MarketUpdater + OrderGenerator + FillUpdater,
-    Data: MarketGenerator + Send,
+    Data: MarketGenerator<MarketEvent<DataKind>> + Send,
     Strategy: SignalGenerator + Send,
     Execution: ExecutionClient + Send,
 {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,12 @@
-use crate::execution::FillEvent;
-use crate::portfolio::position::{Position, PositionExit, PositionUpdate};
-use crate::portfolio::{Balance, OrderEvent};
-use crate::strategy::{Signal, SignalForceExit};
-use barter_data::model::MarketEvent;
+use crate::{
+    execution::FillEvent,
+    portfolio::{
+        position::{Position, PositionExit, PositionUpdate},
+        Balance, OrderEvent,
+    },
+    strategy::{Signal, SignalForceExit},
+};
+use barter_data::event::{DataKind, MarketEvent};
 use serde::Serialize;
 use std::fmt::Debug;
 use tokio::sync::mpsc;
@@ -14,7 +18,7 @@ use tracing::warn;
 /// system, and is useful for analysing performance & reconciliations.
 #[derive(Clone, PartialEq, Debug, Serialize)]
 pub enum Event {
-    Market(MarketEvent),
+    Market(MarketEvent<DataKind>),
     Signal(Signal),
     SignalForceExit(SignalForceExit),
     OrderNew(OrderEvent),

--- a/src/portfolio/mod.rs
+++ b/src/portfolio/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     portfolio::{error::PortfolioError, position::PositionUpdate},
     strategy::{Decision, Signal, SignalForceExit},
 };
-use barter_data::model::MarketEvent;
+use barter_data::event::{DataKind, MarketEvent};
 use barter_integration::model::{Exchange, Instrument};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ pub trait MarketUpdater {
     /// changes.
     fn update_from_market(
         &mut self,
-        market: &MarketEvent,
+        market: &MarketEvent<DataKind>,
     ) -> Result<Option<PositionUpdate>, PortfolioError>;
 }
 

--- a/src/portfolio/portfolio.rs
+++ b/src/portfolio/portfolio.rs
@@ -16,7 +16,7 @@ use crate::{
     statistic::summary::{Initialiser, PositionSummariser},
     strategy::{Decision, Signal, SignalForceExit, SignalStrength},
 };
-use barter_data::model::MarketEvent;
+use barter_data::event::{DataKind, MarketEvent};
 use barter_integration::model::{Market, MarketId, Side};
 use chrono::Utc;
 use serde::Serialize;
@@ -86,7 +86,7 @@ where
 {
     fn update_from_market(
         &mut self,
-        market: &MarketEvent,
+        market: &MarketEvent<DataKind>,
     ) -> Result<Option<PositionUpdate>, PortfolioError> {
         // Determine the position_id associated to the input MarketEvent
         let position_id =
@@ -559,9 +559,7 @@ pub mod tests {
     use crate::portfolio::risk::DefaultRisk;
     use crate::statistic::summary::pnl::PnLReturnSummary;
     use crate::strategy::SignalForceExit;
-    use crate::test_util::{fill_event, position, signal};
-    use barter_data::model::DataKind;
-    use barter_data::test_util::market_trade;
+    use crate::test_util::{fill_event, market_event_trade, position, signal};
     use barter_integration::model::{Exchange, Instrument, InstrumentKind, Side};
 
     #[derive(Default)]
@@ -743,14 +741,13 @@ pub mod tests {
         let mut portfolio = new_mocked_portfolio(mock_repository).unwrap();
 
         // Input MarketEvent
-        let mut input_market = market_trade(Side::Buy);
+        let mut input_market = market_event_trade(Side::Buy);
 
         match input_market.kind {
             // candle.close +100.0 on input_position.current_symbol_price
             DataKind::Candle(ref mut candle) => candle.close = 200.0,
             DataKind::Trade(ref mut trade) => trade.price = 200.0,
-            DataKind::OrderBook(_) => todo!(),
-            DataKind::Liquidation(_) => todo!(),
+            _ => todo!(),
         };
 
         let result_pos_update = portfolio
@@ -793,13 +790,12 @@ pub mod tests {
         let mut portfolio = new_mocked_portfolio(mock_repository).unwrap();
 
         // Input MarketEvent
-        let mut input_market = market_trade(Side::Buy);
+        let mut input_market = market_event_trade(Side::Buy);
         match input_market.kind {
             // -50.0 on input_position.current_symbol_price
             DataKind::Candle(ref mut candle) => candle.close = 50.0,
             DataKind::Trade(ref mut trade) => trade.price = 50.0,
-            DataKind::OrderBook(_) => todo!(),
-            DataKind::Liquidation(_) => todo!(),
+            _ => todo!(),
         };
 
         let result_pos_update = portfolio
@@ -838,14 +834,13 @@ pub mod tests {
         let mut portfolio = new_mocked_portfolio(mock_repository).unwrap();
 
         // Input MarketEvent
-        let mut input_market = market_trade(Side::Buy);
+        let mut input_market = market_event_trade(Side::Buy);
 
         match input_market.kind {
             // -50.0 on input_position.current_symbol_price
             DataKind::Candle(ref mut candle) => candle.close = 50.0,
             DataKind::Trade(ref mut trade) => trade.price = 50.0,
-            DataKind::OrderBook(_) => todo!(),
-            DataKind::Liquidation(_) => todo!(),
+            _ => todo!(),
         };
 
         let result_pos_update = portfolio
@@ -884,14 +879,13 @@ pub mod tests {
         let mut portfolio = new_mocked_portfolio(mock_repository).unwrap();
 
         // Input MarketEvent
-        let mut input_market = market_trade(Side::Buy);
+        let mut input_market = market_event_trade(Side::Buy);
 
         match input_market.kind {
             // +100.0 on input_position.current_symbol_price
             DataKind::Candle(ref mut candle) => candle.close = 200.0,
             DataKind::Trade(ref mut trade) => trade.price = 200.0,
-            DataKind::OrderBook(_) => todo!(),
-            DataKind::Liquidation(_) => todo!(),
+            _ => todo!(),
         };
 
         let result_pos_update = portfolio

--- a/src/strategy/example.rs
+++ b/src/strategy/example.rs
@@ -1,6 +1,6 @@
 use super::{Decision, Signal, SignalGenerator, SignalStrength};
 use crate::data::MarketMeta;
-use barter_data::model::{DataKind, MarketEvent};
+use barter_data::event::{DataKind, MarketEvent};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ pub struct RSIStrategy {
 }
 
 impl SignalGenerator for RSIStrategy {
-    fn generate_signal(&mut self, market: &MarketEvent) -> Option<Signal> {
+    fn generate_signal(&mut self, market: &MarketEvent<DataKind>) -> Option<Signal> {
         // Check if it's a MarketEvent with a candle
         let candle_close = match &market.kind {
             DataKind::Candle(candle) => candle.close,

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -1,5 +1,5 @@
 use crate::data::MarketMeta;
-use barter_data::model::MarketEvent;
+use barter_data::event::{DataKind, MarketEvent};
 use barter_integration::model::{Exchange, Instrument, Market};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ pub mod example;
 /// May generate an advisory [`Signal`] as a result of analysing an input [`MarketEvent`].
 pub trait SignalGenerator {
     /// Optionally return a [`Signal`] given input [`MarketEvent`].
-    fn generate_signal(&mut self, market: &MarketEvent) -> Option<Signal>;
+    fn generate_signal(&mut self, market: &MarketEvent<DataKind>) -> Option<Signal>;
 }
 
 /// Advisory [`Signal`] for a [`Market`] detailing the [`SignalStrength`] associated with each

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,8 +15,8 @@ use barter::{
         Initialiser,
     },
     strategy::example::{Config as StrategyConfig, RSIStrategy},
+    test_util::market_event_trade,
 };
-use barter_data::test_util::market_trade;
 use barter_integration::model::{InstrumentKind, Market, Side};
 use parking_lot::Mutex;
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -72,7 +72,7 @@ async fn engine_with_historic_data_stops_after_candles_finished() {
             .event_tx(event_tx.clone())
             .portfolio(Arc::clone(&portfolio))
             .data(historical::MarketFeed::new(
-                [market_trade(Side::Buy)].into_iter(),
+                [market_event_trade(Side::Buy)].into_iter(),
             ))
             .strategy(RSIStrategy::new(StrategyConfig { rsi_period: 14 }))
             .execution(SimulatedExecution::new(ExecutionConfig {


### PR DESCRIPTION
### Refactor
- Update to barter-data 0.6.5
- Update to barter-integration 0.5.1
- Make required changes to integrate new `barter_data::event::MarketEvent<T>` structure.