### PR TITLE
feat: bybit futures

### DIFF
--- a/barter-data/README.md
+++ b/barter-data/README.md
@@ -1,6 +1,6 @@
 
 # Barter-Data
-A high-performance WebSocket integration library for streaming public market data from leading cryptocurrency 
+A high-performance WebSocket integration library for streaming public market data from leading cryptocurrency
 exchanges - batteries included. It is:
 * **Easy**: Barter-Data's simple StreamBuilder interface allows for easy & quick setup (see example below!).
 * **Normalised**: Barter-Data's unified interface for consuming public WebSocket data means every Exchange returns a normalised data model.
@@ -37,11 +37,11 @@ exchanges - batteries included. It is:
 [Chat]: https://discord.gg/wE7RqhnQMV
 
 ## Overview
-Barter-Data is a high-performance WebSocket integration library for streaming public market data from leading cryptocurrency 
+Barter-Data is a high-performance WebSocket integration library for streaming public market data from leading cryptocurrency
 exchanges. It presents an easy-to-use and extensible set of interfaces that can deliver normalised exchange data in real-time.
 
-From a user perspective, the major component is the `StreamBuilder` structures that assists in initialising an 
-arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply build your dream set of 
+From a user perspective, the major component is the `StreamBuilder` structures that assists in initialising an
+arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply build your dream set of
 `MarketStreams` and `Barter-Data` will do the rest!
 
 ### Supported Exchange Subscriptions
@@ -53,7 +53,7 @@ arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply
 |      **Bitfinex**       |            `Bitfinex`            |                    Spot                     |                   PublicTrades                   |
 |       **Bitmex**        |             `Bitmex`             |                  Perpetual                  |                   PublicTrades                   |
 |      **BybitSpot**      |      `BybitSpot::default()`      |                    Spot                     |                   PublicTrades                   |
-| **BybitPerpetualsUsd**  | `BybitPerpetualsUsd::default()`  |                  Perpetual                  |                   PublicTrades                   |
+| **BybitPerpetualsUsd**  | `BybitPerpetualsUsd::default()`  |                  Perpetual                  | PublicTrades <br> OrderBooksL1 <brOrderBooksL2   |
 |      **Coinbase**       |            `Coinbase`            |                    Spot                     |                   PublicTrades                   |
 |     **GateioSpot**      |     `GateioSpot::default()`      |                    Spot                     |                   PublicTrades                   |
 |  **GateioFuturesUsd**   |  `GateioFuturesUsd::default()`   |                   Future                    |                   PublicTrades                   |
@@ -66,7 +66,7 @@ arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply
 
 
 ## Examples
-See barter-data-rs/examples for a more comprehensive selection of examples! 
+See barter-data-rs/examples for a more comprehensive selection of examples!
 
 ### Multi Exchange Public Trades
 ```rust,no_run
@@ -155,11 +155,11 @@ async fn main() {
 ```
 
 ## Getting Help
-Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be 
-happy to help via [Chat] and try answer your question via Discord. 
+Firstly, see if the answer to your question can be found in the [API Documentation]. If the answer is not there, I'd be
+happy to help via [Chat] and try answer your question via Discord.
 
 ## Contributing
-Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord 
+Thanks in advance for helping to develop the Barter ecosystem! Please do get hesitate to get touch via the Discord
 [Chat] to discuss development, new features, and the future roadmap.
 
 ### Adding A New Exchange Connector

--- a/barter-data/examples/bybit.rs
+++ b/barter-data/examples/bybit.rs
@@ -1,0 +1,55 @@
+use barter_data::{
+    event::{DataKind, MarketEvent},
+    exchange::ExchangeId,
+    streams::builder::dynamic::DynamicStreams,
+    subscription::SubKind,
+};
+use barter_integration::model::instrument::{kind::InstrumentKind, Instrument};
+use futures::StreamExt;
+use tracing::info;
+
+#[rustfmt::skip]
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    use ExchangeId::*;
+    use InstrumentKind::*;
+    use SubKind::*;
+
+
+    let streams = DynamicStreams::init([
+        vec![
+            // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, PublicTrades),
+            (BybitPerpetualsUsd, "btc", "usdt", Perpetual, OrderBooksL1),
+            // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, OrderBooksL2),
+            // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, Liquidations),
+        ],
+
+        vec![
+            // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, PublicTrades),
+            (BybitPerpetualsUsd, "eth", "usdt", Perpetual, OrderBooksL1),
+            // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, OrderBooksL2),
+            // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, Liquidations),
+        ],
+    ]).await.unwrap();
+
+    let mut merged = streams
+        .select_all::<MarketEvent<Instrument, DataKind>>();
+
+    while let Some(event) = merged.next().await {
+        info!("{event:?}");
+    }
+}
+
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .json()
+        .init()
+}

--- a/barter-data/examples/bybit.rs
+++ b/barter-data/examples/bybit.rs
@@ -21,14 +21,14 @@ async fn main() {
     let streams = DynamicStreams::init([
         vec![
             // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, PublicTrades),
-            (BybitPerpetualsUsd, "btc", "usdt", Perpetual, OrderBooksL1),
+            // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, OrderBooksL1),
             // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, OrderBooksL2),
-            // (BybitPerpetualsUsd, "btc", "usdt", Perpetual, Liquidations),
+            (BybitPerpetualsUsd, "btc", "usdt", Perpetual, Liquidations),
         ],
 
         vec![
             // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, PublicTrades),
-            (BybitPerpetualsUsd, "eth", "usdt", Perpetual, OrderBooksL1),
+            // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, OrderBooksL1),
             // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, OrderBooksL2),
             // (BybitPerpetualsUsd, "eth", "usdt", Perpetual, Liquidations),
         ],

--- a/barter-data/src/exchange/bybit/book/l1.rs
+++ b/barter-data/src/exchange/bybit/book/l1.rs
@@ -1,0 +1,38 @@
+use crate::{
+    event::{MarketEvent, MarketIter},
+    exchange::{bybit::futures::l2::BybitPerpetualsOrderBookL2, ExchangeId},
+    subscription::book::{Level, OrderBookL1},
+};
+use barter_integration::model::Exchange;
+use chrono::Utc;
+
+use super::BybitLevel;
+
+impl<InstrumentId> From<(ExchangeId, InstrumentId, BybitPerpetualsOrderBookL2)>
+    for MarketIter<InstrumentId, OrderBookL1>
+{
+    fn from(
+        (exchange_id, instrument, book): (ExchangeId, InstrumentId, BybitPerpetualsOrderBookL2),
+    ) -> Self {
+        let best_bid = book.data.bids.first().unwrap_or(&BybitLevel {
+            price: 0.0,
+            amount: 0.0,
+        });
+        let best_ask = book.data.asks.first().unwrap_or(&BybitLevel {
+            price: 0.0,
+            amount: 0.0,
+        });
+
+        Self(vec![Ok(MarketEvent {
+            exchange_time: book.time,
+            received_time: Utc::now(),
+            exchange: Exchange::from(exchange_id),
+            instrument,
+            kind: OrderBookL1 {
+                last_update_time: book.time,
+                best_bid: Level::from((best_bid.price, best_bid.amount)),
+                best_ask: Level::from((best_ask.price, best_ask.amount)),
+            },
+        })])
+    }
+}

--- a/barter-data/src/exchange/bybit/book/l2.rs
+++ b/barter-data/src/exchange/bybit/book/l2.rs
@@ -96,6 +96,10 @@ mod tests {
     use super::*;
 
     mod de {
+        use std::time::Duration;
+
+        use barter_integration::de::datetime_utc_from_epoch_duration;
+
         use super::*;
 
         #[test]
@@ -105,92 +109,55 @@ mod tests {
                 expected: BybitOrderBookL2,
             }
 
-            let time = Utc::now();
+            let res_time = datetime_utc_from_epoch_duration(Duration::from_millis(1716863719382));
+            let time = datetime_utc_from_epoch_duration(Duration::from_millis(1716863719031));
+            let created_time =
+                datetime_utc_from_epoch_duration(Duration::from_millis(1716863718905));
 
-            let tests = vec![
-                TestCase {
-                    // TC0: valid Spot BybitOrderBookL2
-                    input: r#"
+            let tests = vec![TestCase {
+                // TC0: valid BybitOrderBookL2
+                input: r#"
                     {
-                        "lastUpdateId": 1027024,
-                        "bids": [
-                            [
-                                "4.00000000",
-                                "431.00000000"
-                            ]
-                        ],
-                        "asks": [
-                            [
-                                "4.00000200",
-                                "12.00000000"
-                            ]
-                        ]
+                        "retCode": 0,
+                        "retMsg": "OK",
+                        "result": {
+                            "s": "BTCUSDT",
+                            "a": [
+                                ["65557.7", "16.606555"]
+                            ],
+                            "b": [
+                                ["65485.47", "47.081829"]
+                            ],
+                            "ts": 1716863719031,
+                            "u": 230704,
+                            "seq": 1432604333,
+                            "cts": 1716863718905
+                        },
+                        "retExtInfo": {},
+                        "time": 1716863719382
                     }
                     "#,
-                    expected: BybitOrderBookL2 {
-                        ret_code: 0,
-                        ret_msg: "OK".to_string(),
-                        result: BybitOrderBookL2Result {
-                            symbol: "".to_string(),
-                            asks: vec![BybitLevel {
-                                price: 4.00000200,
-                                amount: 12.0,
-                            }],
-                            bids: vec![BybitLevel {
-                                price: 4.0,
-                                amount: 431.0,
-                            }],
-                            time,
-                            last_update_id: 230704,
-                            sequence: 1432604333,
-                            created_time: time,
-                        },
+                expected: BybitOrderBookL2 {
+                    ret_code: 0,
+                    ret_msg: "OK".to_string(),
+                    result: BybitOrderBookL2Result {
+                        symbol: "BTCUSDT".to_string(),
+                        asks: vec![BybitLevel {
+                            price: 65557.7,
+                            amount: 16.606555,
+                        }],
+                        bids: vec![BybitLevel {
+                            price: 65485.47,
+                            amount: 47.081829,
+                        }],
                         time,
+                        last_update_id: 230704,
+                        sequence: 1432604333,
+                        created_time,
                     },
+                    time: res_time,
                 },
-                TestCase {
-                    // TC1: valid FuturePerpetual BybitOrderBookL2
-                    input: r#"
-                    {
-                        "lastUpdateId": 1027024,
-                        "E": 1589436922972,
-                        "T": 1589436922959,
-                        "bids": [
-                            [
-                                "4.00000000",
-                                "431.00000000"
-                            ]
-                        ],
-                        "asks": [
-                            [
-                                "4.00000200",
-                                "12.00000000"
-                            ]
-                        ]
-                    }
-                    "#,
-                    expected: BybitOrderBookL2 {
-                        ret_code: 0,
-                        ret_msg: "OK".to_string(),
-                        result: BybitOrderBookL2Result {
-                            symbol: "".to_string(),
-                            asks: vec![BybitLevel {
-                                price: 4.00000200,
-                                amount: 12.0,
-                            }],
-                            bids: vec![BybitLevel {
-                                price: 4.0,
-                                amount: 431.0,
-                            }],
-                            time,
-                            last_update_id: 230704,
-                            sequence: 1432604333,
-                            created_time: time,
-                        },
-                        time,
-                    },
-                },
-            ];
+            }];
 
             for (index, test) in tests.into_iter().enumerate() {
                 assert_eq!(

--- a/barter-data/src/exchange/bybit/book/l2.rs
+++ b/barter-data/src/exchange/bybit/book/l2.rs
@@ -1,0 +1,205 @@
+use super::BybitLevel;
+use crate::subscription::book::{OrderBook, OrderBookSide};
+use barter_integration::model::Side;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// [`Bybit`](super::super::Bybit) OrderBook Level2 snapshot HTTP message.
+///
+/// Used as the starting [`OrderBook`] before OrderBook Level2 delta WebSocket updates are
+/// applied.
+///
+/// ### Payload Examples
+/// #### BybitPerpetualsUsd OrderBookL2Snapshot
+/// See docs: <https://bybit-exchange.github.io/docs/v5/market/orderbook>
+/// ```json
+/// {
+///     "retCode": 0,
+///     "retMsg": "OK",
+///     "result": {
+///         "s": "BTCUSDT",
+///         "a": [
+///             [
+///                 "65557.7",
+///                 "16.606555"
+///             ]
+///         ],
+///         "b": [
+///             [
+///                 "65485.47",
+///                 "47.081829"
+///             ]
+///         ],
+///         "ts": 1716863719031,
+///         "u": 230704,
+///         "seq": 1432604333,
+///         "cts": 1716863718905
+///     },
+///     "retExtInfo": {},
+///     "time": 1716863719382
+/// }
+/// ```
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitOrderBookL2 {
+    #[serde(rename = "retCode")]
+    pub ret_code: i64,
+    #[serde(rename = "retMsg")]
+    pub ret_msg: String,
+    #[serde(rename = "result")]
+    pub result: BybitOrderBookL2Result,
+    #[serde(
+        alias = "time",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub time: DateTime<Utc>,
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitOrderBookL2Result {
+    #[serde(alias = "s")]
+    pub symbol: String,
+    #[serde(alias = "a")]
+    pub asks: Vec<BybitLevel>,
+    #[serde(alias = "b")]
+    pub bids: Vec<BybitLevel>,
+    #[serde(
+        alias = "ts",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub time: DateTime<Utc>,
+    #[serde(alias = "u")]
+    pub last_update_id: u64,
+    #[serde(alias = "seq")]
+    pub sequence: u64,
+    #[serde(
+        alias = "cts",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub created_time: DateTime<Utc>,
+}
+
+impl From<BybitOrderBookL2> for OrderBook {
+    fn from(snapshot: BybitOrderBookL2) -> Self {
+        Self {
+            last_update_time: Utc::now(),
+            bids: OrderBookSide::new(Side::Buy, snapshot.result.bids),
+            asks: OrderBookSide::new(Side::Sell, snapshot.result.asks),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod de {
+        use super::*;
+
+        #[test]
+        fn test_bybit_order_book_l2_snapshot() {
+            struct TestCase {
+                input: &'static str,
+                expected: BybitOrderBookL2,
+            }
+
+            let time = Utc::now();
+
+            let tests = vec![
+                TestCase {
+                    // TC0: valid Spot BybitOrderBookL2
+                    input: r#"
+                    {
+                        "lastUpdateId": 1027024,
+                        "bids": [
+                            [
+                                "4.00000000",
+                                "431.00000000"
+                            ]
+                        ],
+                        "asks": [
+                            [
+                                "4.00000200",
+                                "12.00000000"
+                            ]
+                        ]
+                    }
+                    "#,
+                    expected: BybitOrderBookL2 {
+                        ret_code: 0,
+                        ret_msg: "OK".to_string(),
+                        result: BybitOrderBookL2Result {
+                            symbol: "".to_string(),
+                            asks: vec![BybitLevel {
+                                price: 4.00000200,
+                                amount: 12.0,
+                            }],
+                            bids: vec![BybitLevel {
+                                price: 4.0,
+                                amount: 431.0,
+                            }],
+                            time,
+                            last_update_id: 230704,
+                            sequence: 1432604333,
+                            created_time: time,
+                        },
+                        time,
+                    },
+                },
+                TestCase {
+                    // TC1: valid FuturePerpetual BybitOrderBookL2
+                    input: r#"
+                    {
+                        "lastUpdateId": 1027024,
+                        "E": 1589436922972,
+                        "T": 1589436922959,
+                        "bids": [
+                            [
+                                "4.00000000",
+                                "431.00000000"
+                            ]
+                        ],
+                        "asks": [
+                            [
+                                "4.00000200",
+                                "12.00000000"
+                            ]
+                        ]
+                    }
+                    "#,
+                    expected: BybitOrderBookL2 {
+                        ret_code: 0,
+                        ret_msg: "OK".to_string(),
+                        result: BybitOrderBookL2Result {
+                            symbol: "".to_string(),
+                            asks: vec![BybitLevel {
+                                price: 4.00000200,
+                                amount: 12.0,
+                            }],
+                            bids: vec![BybitLevel {
+                                price: 4.0,
+                                amount: 431.0,
+                            }],
+                            time,
+                            last_update_id: 230704,
+                            sequence: 1432604333,
+                            created_time: time,
+                        },
+                        time,
+                    },
+                },
+            ];
+
+            for (index, test) in tests.into_iter().enumerate() {
+                assert_eq!(
+                    serde_json::from_str::<BybitOrderBookL2>(test.input).unwrap(),
+                    test.expected,
+                    "TC{} failed",
+                    index
+                );
+            }
+        }
+    }
+}

--- a/barter-data/src/exchange/bybit/book/mod.rs
+++ b/barter-data/src/exchange/bybit/book/mod.rs
@@ -1,0 +1,53 @@
+use crate::subscription::book::Level;
+use serde::{Deserialize, Serialize};
+
+/// Level 1 OrderBook types (top of book).
+pub mod l1;
+
+/// Level 2 OrderBook types (top of book).
+pub mod l2;
+
+/// [`Bybit`](super::Bybit) OrderBook level.
+///
+/// #### Raw Payload Examples
+/// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook>
+/// ```json
+/// ["4.00000200", "12.00000000"]
+/// ```
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitLevel {
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    pub price: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    pub amount: f64,
+}
+
+impl From<BybitLevel> for Level {
+    fn from(level: BybitLevel) -> Self {
+        Self {
+            price: level.price,
+            amount: level.amount,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod de {
+        use super::*;
+
+        #[test]
+        fn test_bybit_level() {
+            let input = r#"["4.00000200", "12.00000000"]"#;
+            assert_eq!(
+                serde_json::from_str::<BybitLevel>(input).unwrap(),
+                BybitLevel {
+                    price: 4.00000200,
+                    amount: 12.0
+                },
+            )
+        }
+    }
+}

--- a/barter-data/src/exchange/bybit/channel.rs
+++ b/barter-data/src/exchange/bybit/channel.rs
@@ -1,13 +1,13 @@
 use crate::{
     exchange::bybit::Bybit,
     subscription::{
-        book::{OrderBooksL1, OrderBooksL2},
-        trade::PublicTrades,
-        Subscription,
+        book::{OrderBooksL1, OrderBooksL2}, liquidation::Liquidations, trade::PublicTrades, Subscription
     },
     Identifier,
 };
 use serde::Serialize;
+
+use super::futures::BybitPerpetualsUsd;
 
 /// Type that defines how to translate a Barter [`Subscription`] into a [`Bybit`]
 /// channel to be subscribed to.
@@ -24,6 +24,8 @@ impl BybitChannel {
     /// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook>
     pub const ORDER_BOOK_L1: Self = Self("orderbook.1");
     pub const ORDER_BOOK_L2: Self = Self("orderbook.50");
+    /// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/liquidation>
+    pub const LIQUIDATIONS: Self = Self("liquidation");
 }
 
 impl<Server, Instrument> Identifier<BybitChannel>
@@ -47,6 +49,14 @@ impl<Server, Instrument> Identifier<BybitChannel>
 {
     fn id(&self) -> BybitChannel {
         BybitChannel::ORDER_BOOK_L2
+    }
+}
+
+impl<Instrument> Identifier<BybitChannel>
+    for Subscription<BybitPerpetualsUsd, Instrument, Liquidations>
+{
+    fn id(&self) -> BybitChannel {
+        BybitChannel::LIQUIDATIONS
     }
 }
 

--- a/barter-data/src/exchange/bybit/channel.rs
+++ b/barter-data/src/exchange/bybit/channel.rs
@@ -1,6 +1,10 @@
 use crate::{
     exchange::bybit::Bybit,
-    subscription::{trade::PublicTrades, Subscription},
+    subscription::{
+        book::{OrderBooksL1, OrderBooksL2},
+        trade::PublicTrades,
+        Subscription,
+    },
     Identifier,
 };
 use serde::Serialize;
@@ -17,6 +21,9 @@ impl BybitChannel {
     ///
     /// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/trade>
     pub const TRADES: Self = Self("publicTrade");
+    /// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook>
+    pub const ORDER_BOOK_L1: Self = Self("orderbook.1");
+    pub const ORDER_BOOK_L2: Self = Self("orderbook.50");
 }
 
 impl<Server, Instrument> Identifier<BybitChannel>
@@ -24,6 +31,22 @@ impl<Server, Instrument> Identifier<BybitChannel>
 {
     fn id(&self) -> BybitChannel {
         BybitChannel::TRADES
+    }
+}
+
+impl<Server, Instrument> Identifier<BybitChannel>
+    for Subscription<Bybit<Server>, Instrument, OrderBooksL1>
+{
+    fn id(&self) -> BybitChannel {
+        BybitChannel::ORDER_BOOK_L1
+    }
+}
+
+impl<Server, Instrument> Identifier<BybitChannel>
+    for Subscription<Bybit<Server>, Instrument, OrderBooksL2>
+{
+    fn id(&self) -> BybitChannel {
+        BybitChannel::ORDER_BOOK_L2
     }
 }
 

--- a/barter-data/src/exchange/bybit/futures/l2.rs
+++ b/barter-data/src/exchange/bybit/futures/l2.rs
@@ -1,0 +1,546 @@
+use super::super::book::{l2::BybitOrderBookL2, BybitLevel};
+use crate::{
+    error::DataError,
+    exchange::{bybit::channel::BybitChannel, subscription::ExchangeSub},
+    subscription::book::{OrderBook, OrderBookSide},
+    transformer::book::{InstrumentOrderBook, OrderBookUpdater},
+    Identifier,
+};
+use async_trait::async_trait;
+use barter_integration::{
+    error::SocketError,
+    model::{instrument::Instrument, Side, SubscriptionId},
+    protocol::websocket::WsMessage,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+/// [`BybitPerpetualsUsd`](super::BybitPerpetualsUsd) HTTP OrderBook L2 snapshot url.
+///
+/// See docs: <https://bybit-exchange.github.io/docs/v5/market/orderbook>
+pub const HTTP_BOOK_L2_SNAPSHOT_URL_BYBIT: &str = "https://api.bybit.com/v5/market/orderbook";
+
+/// [`BybitPerpetualsUsd`](super::BybitPerpetualsUsd) OrderBook Level2 deltas WebSocket message.
+///
+/// ### Raw Payload Examples
+/// See docs: <https://bybit-docs.github.io/apidocs/futures/en/#partial-book-depth-streams>
+/// ```json
+/// {
+///     "topic": "orderbook.50.BTCUSDT",
+///     "type": "delta",
+///     "ts": 1687940967466,
+///     "data": {
+///         "s": "BTCUSDT",
+///         "b": [
+///              ["30240.30", "1.305"],
+///              ["30240.00", "0"]
+///         ],
+///         "a": [
+///             ["30248.70", "0"],
+///             ["30249.30", "0.892"],
+///         ],
+///         "u": 177400507,
+///         "seq": 66544703342
+///     }
+///     "cts": 1687940967464
+/// }
+/// ```
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitPerpetualsOrderBookL2 {
+    #[serde(alias = "topic")]
+    pub topic: String,
+    #[serde(alias = "type")]
+    pub r#type: BybitPerpetualsOrderBookL2Type,
+    #[serde(
+        alias = "ts",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub time: DateTime<Utc>,
+    #[serde(alias = "data")]
+    pub data: BybitPerpetualsOrderBookL2Data,
+    #[serde(
+        alias = "cts",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub created_time: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub enum BybitPerpetualsOrderBookL2Type {
+    #[serde(alias = "delta")]
+    Delta,
+    #[serde(alias = "snapshot")]
+    Snapshot,
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitPerpetualsOrderBookL2Data {
+    #[serde(alias = "s", deserialize_with = "de_ob_l2_subscription_id")]
+    pub subscription_id: SubscriptionId,
+    #[serde(alias = "b")]
+    pub bids: Vec<BybitLevel>,
+    #[serde(alias = "a")]
+    pub asks: Vec<BybitLevel>,
+    #[serde(alias = "u")]
+    pub update_id: u64,
+    #[serde(alias = "seq")]
+    pub sequence: u64,
+}
+
+impl Identifier<Option<SubscriptionId>> for BybitPerpetualsOrderBookL2 {
+    fn id(&self) -> Option<SubscriptionId> {
+        Some(self.data.subscription_id.clone())
+    }
+}
+
+/// [`Bybit`](super::super::Bybit) [`BybitServerFuturesUsd`](super::BybitServerFuturesUsd)
+/// [`OrderBookUpdater`].
+///
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct BybitPerpetualsBookUpdater {
+    pub last_update_id: u64,
+    pub last_sequence: u64,
+}
+
+impl BybitPerpetualsBookUpdater {
+    /// Construct a new BybitPerpetuals [`OrderBookUpdater`] using the provided last_update_id from
+    /// a HTTP snapshot.
+    pub fn new(last_update_id: u64, last_sequence: u64) -> Self {
+        Self {
+            last_update_id,
+            last_sequence,
+        }
+    }
+
+    pub fn validate_next_update(
+        &self,
+        update: &BybitPerpetualsOrderBookL2,
+    ) -> Result<(), DataError> {
+        if update.r#type == BybitPerpetualsOrderBookL2Type::Snapshot {
+            return Ok(());
+        }
+        if update.data.update_id == self.last_update_id + 1 {
+            Ok(())
+        } else {
+            Err(DataError::InvalidSequence {
+                prev_last_update_id: self.last_update_id,
+                first_update_id: update.data.update_id, // TODO
+            })
+        }
+    }
+}
+
+#[async_trait]
+impl OrderBookUpdater for BybitPerpetualsBookUpdater {
+    type OrderBook = OrderBook;
+    type Update = BybitPerpetualsOrderBookL2;
+
+    async fn init<Exchange, Kind>(
+        _: mpsc::UnboundedSender<WsMessage>,
+        instrument: Instrument,
+    ) -> Result<InstrumentOrderBook<Instrument, Self>, DataError>
+    where
+        Exchange: Send,
+        Kind: Send,
+    {
+        // Construct initial OrderBook snapshot GET url
+        let snapshot_url = format!(
+            "{}?category=linear&symbol={}{}&limit=100",
+            HTTP_BOOK_L2_SNAPSHOT_URL_BYBIT,
+            instrument.base.as_ref().to_uppercase(),
+            instrument.quote.as_ref().to_uppercase()
+        );
+
+        // Fetch initial OrderBook snapshot via HTTP
+        let snapshot = reqwest::get(snapshot_url)
+            .await
+            .map_err(SocketError::Http)?
+            .json::<BybitOrderBookL2>()
+            .await
+            .map_err(SocketError::Http)?;
+
+        Ok(InstrumentOrderBook {
+            instrument,
+            updater: Self::new(snapshot.result.last_update_id, snapshot.result.sequence),
+            book: OrderBook::from(snapshot),
+        })
+    }
+
+    fn update(
+        &mut self,
+        book: &mut Self::OrderBook,
+        update: Self::Update,
+    ) -> Result<Option<Self::OrderBook>, DataError> {
+        if update.data.update_id < self.last_update_id {
+            return Ok(None);
+        }
+
+        self.validate_next_update(&update)?;
+
+        if update.r#type == BybitPerpetualsOrderBookL2Type::Snapshot {
+            // Replace OrderBook with snapshot
+            book.last_update_time = Utc::now();
+            book.bids = OrderBookSide::new(Side::Buy, update.data.bids);
+            book.asks = OrderBookSide::new(Side::Sell, update.data.asks);
+        } else {
+            // Update OrderBook metadata & Levels:
+            // The data in each event is the absolute quantity for a price level.
+            // If the quantity is 0, remove the price level.
+            book.last_update_time = Utc::now();
+            book.bids.upsert(update.data.bids);
+            book.asks.upsert(update.data.asks);
+        }
+
+        // Update OrderBookUpdater metadata
+        self.last_update_id = update.data.update_id;
+        self.last_sequence = update.data.sequence;
+
+        Ok(Some(book.snapshot()))
+    }
+}
+
+/// Deserialize a [`BybitOrderBookL2`] "s" (eg/ "BTCUSDT") as the associated [`SubscriptionId`].
+///
+/// eg/ "orderbook.1.BTCUSDT"
+pub fn de_ob_l2_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    <&str as Deserialize>::deserialize(deserializer)
+        .map(|market| ExchangeSub::from((BybitChannel::ORDER_BOOK_L1, market)).id())
+    // TODO
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod de {
+        use super::*;
+
+        #[test]
+        fn test_bybit_futures_order_book_l2_deltas() {
+            let input = r#"
+            {
+                "topic": "orderbook.50.BTCUSDT",
+                "type": "delta",
+                "ts": 1687940967466,
+                "data": {
+                    "s": "BTCUSDT",
+                    "b": [
+                        ["30247.20", "30.028"],
+                        ["30245.40", "0.224"],
+                        ["30242.10", "1.593"],
+                        ["30240.30", "1.305"],
+                        ["30240.00", "0"]
+                    ],
+                    "a": [
+                        ["30248.70", "0"],
+                        ["30249.30", "0.892"],
+                        ["30249.50", "1.778"],
+                        ["30249.60", "0"],
+                        ["30251.90", "2.947"],
+                        ["30252.20", "0.659"],
+                        ["30252.50", "4.591"]
+                    ],
+                    "u": 177400507,
+                    "seq": 66544703342
+                },
+                "cts": 1687940967464
+            }
+        "#;
+
+            let time = Utc::now();
+
+            assert_eq!(
+                serde_json::from_str::<BybitPerpetualsOrderBookL2>(input).unwrap(),
+                BybitPerpetualsOrderBookL2 {
+                    topic: "orderbook.50.BTCUSDT".to_string(),
+                    r#type: BybitPerpetualsOrderBookL2Type::Delta,
+                    time,
+                    data: BybitPerpetualsOrderBookL2Data {
+                        subscription_id: SubscriptionId::from("orderbook.50|BTCUSDT"),
+                        bids: vec![
+                            BybitLevel {
+                                price: 30247.20,
+                                amount: 30.028
+                            },
+                            BybitLevel {
+                                price: 30245.40,
+                                amount: 0.224
+                            },
+                            BybitLevel {
+                                price: 30242.10,
+                                amount: 1.593
+                            },
+                            BybitLevel {
+                                price: 30240.30,
+                                amount: 1.305
+                            },
+                            BybitLevel {
+                                price: 30240.00,
+                                amount: 0.0
+                            }
+                        ],
+                        asks: vec![
+                            BybitLevel {
+                                price: 30248.70,
+                                amount: 0.0
+                            },
+                            BybitLevel {
+                                price: 30249.30,
+                                amount: 0.892
+                            },
+                            BybitLevel {
+                                price: 30249.50,
+                                amount: 1.778
+                            },
+                            BybitLevel {
+                                price: 30249.60,
+                                amount: 0.0
+                            },
+                            BybitLevel {
+                                price: 30251.90,
+                                amount: 2.947
+                            },
+                            BybitLevel {
+                                price: 30252.20,
+                                amount: 0.659
+                            },
+                            BybitLevel {
+                                price: 30252.50,
+                                amount: 4.591
+                            }
+                        ],
+                        update_id: 177400507,
+                        sequence: 66544703342
+                    },
+                    created_time: time,
+                }
+            );
+        }
+    }
+
+    mod bybit_futures_book_updater {
+        use super::*;
+        use crate::subscription::book::{Level, OrderBookSide};
+        use barter_integration::model::Side;
+
+        #[test]
+        fn test_validate_next_update() {
+            struct TestCase {
+                updater: BybitPerpetualsBookUpdater,
+                input: BybitPerpetualsOrderBookL2,
+                expected: Result<(), DataError>,
+            }
+
+            let time = Utc::now();
+
+            let tests = vec![
+                TestCase {
+                    // TC0: valid next update
+                    updater: BybitPerpetualsBookUpdater {
+                        last_update_id: 100,
+                        last_sequence: 0,
+                    },
+                    input: BybitPerpetualsOrderBookL2 {
+                        topic: "orderbook.50.BTCUSDT".to_string(),
+                        r#type: BybitPerpetualsOrderBookL2Type::Delta,
+                        time,
+                        data: BybitPerpetualsOrderBookL2Data {
+                            subscription_id: SubscriptionId::from("orderbook.50|BTCUSDT"),
+                            bids: vec![],
+                            asks: vec![],
+                            update_id: 101,
+                            sequence: 66544703342,
+                        },
+                        created_time: time,
+                    },
+                    expected: Ok(()),
+                },
+                TestCase {
+                    // TC1: invalid update_id
+                    updater: BybitPerpetualsBookUpdater {
+                        last_update_id: 100,
+                        last_sequence: 0,
+                    },
+                    input: BybitPerpetualsOrderBookL2 {
+                        topic: "orderbook.50.BTCUSDT".to_string(),
+                        r#type: BybitPerpetualsOrderBookL2Type::Delta,
+                        time,
+                        data: BybitPerpetualsOrderBookL2Data {
+                            subscription_id: SubscriptionId::from("orderbook.50|BTCUSDT"),
+                            bids: vec![],
+                            asks: vec![],
+                            update_id: 100,
+                            sequence: 66544703342,
+                        },
+                        created_time: time,
+                    },
+                    expected: Err(DataError::InvalidSequence {
+                        prev_last_update_id: 100,
+                        first_update_id: 100,
+                    }),
+                },
+            ];
+
+            for (index, test) in tests.into_iter().enumerate() {
+                let actual = test.updater.validate_next_update(&test.input);
+                match (actual, test.expected) {
+                    (Ok(actual), Ok(expected)) => {
+                        assert_eq!(actual, expected, "TC{} failed", index)
+                    }
+                    (Err(_), Err(_)) => {
+                        // Test passed
+                    }
+                    (actual, expected) => {
+                        // Test failed
+                        panic!("TC{index} failed because actual != expected. \nActual: {actual:?}\nExpected: {expected:?}\n");
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn update() {
+            struct TestCase {
+                updater: BybitPerpetualsBookUpdater,
+                book: OrderBook,
+                input_update: BybitPerpetualsOrderBookL2,
+                expected: Result<Option<OrderBook>, DataError>,
+            }
+
+            let time = Utc::now();
+
+            let tests = vec![
+                TestCase {
+                    // TC0: Drop any event where u is < lastUpdateId in the snapshot
+                    updater: BybitPerpetualsBookUpdater {
+                        last_update_id: 100,
+                        last_sequence: 0,
+                    },
+                    book: OrderBook {
+                        last_update_time: time,
+                        bids: OrderBookSide::new(Side::Buy, vec![Level::new(50, 1)]),
+                        asks: OrderBookSide::new(Side::Sell, vec![Level::new(100, 1)]),
+                    },
+                    input_update: BybitPerpetualsOrderBookL2 {
+                        topic: "orderbook.50.BTCUSDT".to_string(),
+                        r#type: BybitPerpetualsOrderBookL2Type::Delta,
+                        time,
+                        data: BybitPerpetualsOrderBookL2Data {
+                            subscription_id: SubscriptionId::from("BTCUSDT"),
+                            bids: vec![],
+                            asks: vec![],
+                            update_id: 99,
+                            sequence: 66544703342,
+                        },
+                        created_time: time,
+                    },
+                    expected: Ok(None),
+                },
+                TestCase {
+                    // TC1: valid update with sorted snapshot generated
+                    updater: BybitPerpetualsBookUpdater {
+                        last_update_id: 100,
+                        last_sequence: 0,
+                    },
+                    book: OrderBook {
+                        last_update_time: time,
+                        bids: OrderBookSide::new(
+                            Side::Buy,
+                            vec![Level::new(80, 1), Level::new(100, 1), Level::new(90, 1)],
+                        ),
+                        asks: OrderBookSide::new(
+                            Side::Sell,
+                            vec![Level::new(150, 1), Level::new(110, 1), Level::new(120, 1)],
+                        ),
+                    },
+                    input_update: BybitPerpetualsOrderBookL2 {
+                        topic: "orderbook.50.BTCUSDT".to_string(),
+                        r#type: BybitPerpetualsOrderBookL2Type::Snapshot,
+                        time,
+                        data: BybitPerpetualsOrderBookL2Data {
+                            subscription_id: SubscriptionId::from("BTCUSDT"),
+                            bids: vec![
+                                BybitLevel {
+                                    price: 100.0,
+                                    amount: 1.0,
+                                },
+                                BybitLevel {
+                                    price: 90.0,
+                                    amount: 10.0,
+                                },
+                            ],
+                            asks: vec![
+                                BybitLevel {
+                                    price: 110.0,
+                                    amount: 1.0,
+                                },
+                                BybitLevel {
+                                    price: 120.0,
+                                    amount: 1.0,
+                                },
+                                BybitLevel {
+                                    price: 150.0,
+                                    amount: 1.0,
+                                },
+                                BybitLevel {
+                                    price: 200.0,
+                                    amount: 1.0,
+                                },
+                            ],
+                            update_id: 100,
+                            sequence: 66544703342,
+                        },
+                        created_time: time,
+                    },
+                    expected: Ok(Some(OrderBook {
+                        last_update_time: time,
+                        bids: OrderBookSide::new(
+                            Side::Buy,
+                            vec![Level::new(100, 1), Level::new(90, 10)],
+                        ),
+                        asks: OrderBookSide::new(
+                            Side::Sell,
+                            vec![
+                                Level::new(110, 1),
+                                Level::new(120, 1),
+                                Level::new(150, 1),
+                                Level::new(200, 1),
+                            ],
+                        ),
+                    })),
+                },
+            ];
+
+            for (index, mut test) in tests.into_iter().enumerate() {
+                let actual = test.updater.update(&mut test.book, test.input_update);
+
+                match (actual, test.expected) {
+                    (Ok(Some(actual)), Ok(Some(expected))) => {
+                        // Replace time with deterministic timestamp
+                        let actual = OrderBook {
+                            last_update_time: time,
+                            ..actual
+                        };
+                        assert_eq!(actual, expected, "TC{} failed", index)
+                    }
+                    (Ok(None), Ok(None)) => {
+                        // Test passed
+                    }
+                    (Err(_), Err(_)) => {
+                        // Test passed
+                    }
+                    (actual, expected) => {
+                        // Test failed
+                        panic!("TC{index} failed because actual != expected. \nActual: {actual:?}\nExpected: {expected:?}\n");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/barter-data/src/exchange/bybit/futures/l2.rs
+++ b/barter-data/src/exchange/bybit/futures/l2.rs
@@ -204,14 +204,13 @@ impl OrderBookUpdater for BybitPerpetualsBookUpdater {
 
 /// Deserialize a [`BybitOrderBookL2`] "s" (eg/ "BTCUSDT") as the associated [`SubscriptionId`].
 ///
-/// eg/ "orderbook.1.BTCUSDT"
+/// eg/ "orderbook.50.BTCUSDT"
 pub fn de_ob_l2_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
     <&str as Deserialize>::deserialize(deserializer)
-        .map(|market| ExchangeSub::from((BybitChannel::ORDER_BOOK_L1, market)).id())
-    // TODO
+        .map(|market| ExchangeSub::from((BybitChannel::ORDER_BOOK_L2, market)).id())
 }
 
 #[cfg(test)]
@@ -219,6 +218,10 @@ mod tests {
     use super::*;
 
     mod de {
+        use std::time::Duration;
+
+        use barter_integration::de::datetime_utc_from_epoch_duration;
+
         use super::*;
 
         #[test]
@@ -253,7 +256,8 @@ mod tests {
             }
         "#;
 
-            let time = Utc::now();
+        let time = datetime_utc_from_epoch_duration(Duration::from_millis(1687940967466));
+        let created_time = datetime_utc_from_epoch_duration(Duration::from_millis(1687940967464));
 
             assert_eq!(
                 serde_json::from_str::<BybitPerpetualsOrderBookL2>(input).unwrap(),
@@ -318,7 +322,7 @@ mod tests {
                         update_id: 177400507,
                         sequence: 66544703342
                     },
-                    created_time: time,
+                    created_time,
                 }
             );
         }

--- a/barter-data/src/exchange/bybit/futures/liquidation.rs
+++ b/barter-data/src/exchange/bybit/futures/liquidation.rs
@@ -1,0 +1,159 @@
+use super::super::BybitChannel;
+use crate::{
+    event::{MarketEvent, MarketIter},
+    exchange::ExchangeId,
+    subscription::liquidation::Liquidation,
+    Identifier,
+};
+use barter_integration::model::{Exchange, Side, SubscriptionId};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// [`BybitFuturesUsd`](super::BybitFuturesUsd) Liquidation message.
+///
+/// ### Raw Payload Examples
+/// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/liquidation>
+/// ```json
+/// {
+///     "topic": "liquidation.BTCUSDT",
+///     "type": "snapshot",
+///     "ts": 1703485237953,
+///     "data": {
+///         "updatedTime": 1703485237953,
+///         "symbol": "BTCUSDT",
+///         "side": "Sell",
+///         "size": "0.003",
+///         "price": "43511.70"
+///     }
+/// }
+/// ```
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitLiquidation {
+    pub topic: String,
+    #[serde(alias = "type")]
+    pub r#type: String,
+    #[serde(
+        alias = "ts",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc"
+    )]
+    pub time: DateTime<Utc>,
+    #[serde(alias = "data")]
+    pub data: BybitLiquidationData,
+}
+
+/// [`BybitFuturesUsd`](super::BybitFuturesUsd) Liquidation data.
+///
+/// ### Raw Payload Examples
+/// ```json
+/// {
+///    "updatedTime": 1703485237953,
+///    "symbol": "BTCUSDT",
+///    "side": "Sell",
+///    "size": "0.003",
+///    "price": "43511.70"
+/// }
+/// ```
+///
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct BybitLiquidationData {
+    #[serde(alias = "symbol", deserialize_with = "de_liquidation_subscription_id")]
+    pub subscription_id: SubscriptionId,
+    #[serde(alias = "side")]
+    pub side: Side,
+    #[serde(alias = "price", deserialize_with = "barter_integration::de::de_str")]
+    pub price: f64,
+    #[serde(alias = "size", deserialize_with = "barter_integration::de::de_str")]
+    pub size: f64,
+    #[serde(
+        alias = "updatedTime",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc"
+    )]
+    pub updated_time: DateTime<Utc>,
+}
+
+impl Identifier<Option<SubscriptionId>> for BybitLiquidation {
+    fn id(&self) -> Option<SubscriptionId> {
+        Some(self.data.subscription_id.clone())
+    }
+}
+
+impl<InstrumentId> From<(ExchangeId, InstrumentId, BybitLiquidation)>
+    for MarketIter<InstrumentId, Liquidation>
+{
+    fn from(
+        (exchange_id, instrument, liquidation): (ExchangeId, InstrumentId, BybitLiquidation),
+    ) -> Self {
+        Self(vec![Ok(MarketEvent {
+            exchange_time: liquidation.time,
+            received_time: Utc::now(),
+            exchange: Exchange::from(exchange_id),
+            instrument,
+            kind: Liquidation {
+                side: liquidation.data.side,
+                price: liquidation.data.price,
+                quantity: liquidation.data.size,
+                time: liquidation.data.updated_time,
+            },
+        })])
+    }
+}
+
+/// Deserialize a [`BybitLiquidationData`] "s" (eg/ "BTCUSDT") as the associated
+/// [`SubscriptionId`].
+///
+/// eg/ "liquidation.BTCUSDT"
+pub fn de_liquidation_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(|market: String| {
+        SubscriptionId::from(format!("{}.{}", BybitChannel::LIQUIDATIONS.0, market))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod de {
+        use super::*;
+        use barter_integration::de::datetime_utc_from_epoch_duration;
+        use std::time::Duration;
+
+        #[test]
+        fn test_bybit_liquidation() {
+            let input = r#"
+            {
+                "topic": "liquidation.BTCUSDT",
+                "type": "snapshot",
+                "ts": 1703485237953,
+                "data": {
+                    "updatedTime": 1703485237953,
+                    "symbol": "BTCUSDT",
+                    "side": "Sell",
+                    "size": "0.003",
+                    "price": "43511.70"
+                }
+            }
+            "#;
+
+            let time = datetime_utc_from_epoch_duration(Duration::from_millis(1703485237953));
+
+            assert_eq!(
+                serde_json::from_str::<BybitLiquidation>(input).unwrap(),
+                BybitLiquidation {
+                    topic: "liquidation.BTCUSDT".to_string(),
+                    r#type: "snapshot".to_string(),
+                    time,
+                    data: BybitLiquidationData {
+                        subscription_id: SubscriptionId::from("liquidation.BTCUSDT"),
+                        side: Side::Sell,
+                        price: 43511.70,
+                        size: 0.003,
+                        updated_time: time,
+                    },
+                }
+            );
+        }
+    }
+}

--- a/barter-data/src/exchange/bybit/futures/mod.rs
+++ b/barter-data/src/exchange/bybit/futures/mod.rs
@@ -1,10 +1,22 @@
+use barter_integration::model::instrument::Instrument;
+use l2::BybitPerpetualsBookUpdater;
+
 use super::{Bybit, ExchangeServer};
-use crate::exchange::ExchangeId;
+use crate::{
+    exchange::{ExchangeId, StreamSelector},
+    subscription::book::OrderBooksL2,
+    transformer::book::MultiBookTransformer,
+    ExchangeWsStream,
+};
 
 /// [`BybitPerpetualsUsd`] WebSocket server base url.
 ///
 /// See docs: <https://bybit-exchange.github.io/docs/v5/ws/connect>
 pub const WEBSOCKET_BASE_URL_BYBIT_PERPETUALS_USD: &str = "wss://stream.bybit.com/v5/public/linear";
+
+/// Level 2 OrderBook types (top of book) and perpetual
+/// [`OrderBookUpdater`](crate::transformer::book::OrderBookUpdater) implementation.
+pub mod l2;
 
 /// [`Bybit`] perpetual exchange.
 pub type BybitPerpetualsUsd = Bybit<BybitServerPerpetualsUsd>;
@@ -19,4 +31,10 @@ impl ExchangeServer for BybitServerPerpetualsUsd {
     fn websocket_url() -> &'static str {
         WEBSOCKET_BASE_URL_BYBIT_PERPETUALS_USD
     }
+}
+
+impl StreamSelector<Instrument, OrderBooksL2> for BybitPerpetualsUsd {
+    type Stream = ExchangeWsStream<
+        MultiBookTransformer<Self, Instrument, OrderBooksL2, BybitPerpetualsBookUpdater>,
+    >;
 }

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -232,7 +232,7 @@ impl ExchangeId {
             (Bitfinex, Spot, PublicTrades) => true,
             (Bitmex, Perpetual, PublicTrades) => true,
             (BybitSpot, Spot, PublicTrades) => true,
-            (BybitPerpetualsUsd, Perpetual, PublicTrades | OrderBooksL1) => true,
+            (BybitPerpetualsUsd, Perpetual, PublicTrades | OrderBooksL1 | Liquidations) => true,
             (Coinbase, Spot, PublicTrades) => true,
             (GateioSpot, Spot, PublicTrades) => true,
             (GateioFuturesUsd, Future(_), PublicTrades) => true,

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -232,7 +232,7 @@ impl ExchangeId {
             (Bitfinex, Spot, PublicTrades) => true,
             (Bitmex, Perpetual, PublicTrades) => true,
             (BybitSpot, Spot, PublicTrades) => true,
-            (BybitPerpetualsUsd, Perpetual, PublicTrades) => true,
+            (BybitPerpetualsUsd, Perpetual, PublicTrades | OrderBooksL1) => true,
             (Coinbase, Spot, PublicTrades) => true,
             (GateioSpot, Spot, PublicTrades) => true,
             (GateioFuturesUsd, Future(_), PublicTrades) => true,

--- a/barter-data/src/streams/builder/dynamic.rs
+++ b/barter-data/src/streams/builder/dynamic.rs
@@ -76,6 +76,7 @@ impl<InstrumentId> DynamicStreams<InstrumentId> {
         Subscription<Bitmex, Instrument, PublicTrades>: Identifier<BitmexMarket>,
         Subscription<BybitSpot, Instrument, PublicTrades>: Identifier<BybitMarket>,
         Subscription<BybitPerpetualsUsd, Instrument, PublicTrades>: Identifier<BybitMarket>,
+        Subscription<BybitPerpetualsUsd, Instrument, OrderBooksL1>: Identifier<BybitMarket>,
         Subscription<Coinbase, Instrument, PublicTrades>: Identifier<CoinbaseMarket>,
         Subscription<GateioSpot, Instrument, PublicTrades>: Identifier<GateioMarket>,
         Subscription<GateioFuturesUsd, Instrument, PublicTrades>: Identifier<GateioMarket>,
@@ -218,6 +219,20 @@ impl<InstrumentId> DynamicStreams<InstrumentId> {
                                 })
                                 .collect(),
                             channels.trades.entry(exchange).or_default().tx.clone(),
+                        ));
+                    }
+                    (ExchangeId::BybitPerpetualsUsd, SubKind::OrderBooksL1) => {
+                        tokio::spawn(consume::<BybitPerpetualsUsd, Instrument, OrderBooksL1>(
+                            subs.into_iter()
+                                .map(|sub| {
+                                    Subscription::<_, Instrument, _>::new(
+                                        BybitPerpetualsUsd::default(),
+                                        sub.instrument,
+                                        OrderBooksL1,
+                                    )
+                                })
+                                .collect(),
+                            channels.l1s.entry(exchange).or_default().tx.clone(),
                         ));
                     }
                     (ExchangeId::Coinbase, SubKind::PublicTrades) => {

--- a/barter-data/src/streams/builder/dynamic.rs
+++ b/barter-data/src/streams/builder/dynamic.rs
@@ -77,6 +77,7 @@ impl<InstrumentId> DynamicStreams<InstrumentId> {
         Subscription<BybitSpot, Instrument, PublicTrades>: Identifier<BybitMarket>,
         Subscription<BybitPerpetualsUsd, Instrument, PublicTrades>: Identifier<BybitMarket>,
         Subscription<BybitPerpetualsUsd, Instrument, OrderBooksL1>: Identifier<BybitMarket>,
+        Subscription<BybitPerpetualsUsd, Instrument, Liquidations>: Identifier<BybitMarket>,
         Subscription<Coinbase, Instrument, PublicTrades>: Identifier<CoinbaseMarket>,
         Subscription<GateioSpot, Instrument, PublicTrades>: Identifier<GateioMarket>,
         Subscription<GateioFuturesUsd, Instrument, PublicTrades>: Identifier<GateioMarket>,
@@ -233,6 +234,25 @@ impl<InstrumentId> DynamicStreams<InstrumentId> {
                                 })
                                 .collect(),
                             channels.l1s.entry(exchange).or_default().tx.clone(),
+                        ));
+                    }
+                    (ExchangeId::BybitPerpetualsUsd, SubKind::Liquidations) => {
+                        tokio::spawn(consume::<BybitPerpetualsUsd, Instrument, Liquidations>(
+                            subs.into_iter()
+                                .map(|sub| {
+                                    Subscription::<_, Instrument, _>::new(
+                                        BybitPerpetualsUsd::default(),
+                                        sub.instrument,
+                                        Liquidations,
+                                    )
+                                })
+                                .collect(),
+                            channels
+                                .liquidations
+                                .entry(exchange)
+                                .or_default()
+                                .tx
+                                .clone(),
                         ));
                     }
                     (ExchangeId::Coinbase, SubKind::PublicTrades) => {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 edition = "2021"
-imports_granularity = "crate"
+imports_granularity = "Crate"


### PR DESCRIPTION
I started to write some bybit futures code.
Don't hesitate to ask for changes.

The challenge was to follow the current architecture with the bybit api.
They have now a unified v5 api which is used for spot and futures at the same time, and the order book handling is different than others, we don't have to fetch by http a snapshot before, there is a type snapshot or delta in the WS message. Same thing with the L1, it's juste a L2 with 1 depth... I'm new to the barter code and tried my best, but this is still a draft, don't hesitate to give me advices to continue helping!

I must be missing something for now as I get the unwrap_or in the L1 for now sometimes, I don't know how to get the best bid/ask while using the same L2 logic

I only add the depth 50 for the L2 for now, but I wait for your inputs to add the others as I actually don't know how you want to tackle this param:

```
Level 1 data, push frequency: 10ms
Level 50 data, push frequency: 20ms
Level 200 data, push frequency: 100ms
Level 500 data, push frequency: 100ms
```

Cheers!