### PR TITLE
coinbase advance trade data api

### DIFF
--- a/barter-data/src/exchange/coinbase_advanced_trade/candles.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/candles.rs
@@ -1,0 +1,136 @@
+use crate::event::{MarketEvent, MarketIter};
+use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
+use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
+use crate::exchange::subscription::ExchangeSub;
+use crate::subscription::candle::{Candle, Candles};
+use crate::Identifier;
+use barter_instrument::exchange::ExchangeId;
+use barter_integration::subscription::SubscriptionId;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Coinbase candles WebSocket message.
+/// ### Raw Payload Examples
+/// ```json
+/// {
+///   "channel": "candles",
+///   "client_id": "",
+///   "timestamp": "2023-06-09T20:19:35.39625135Z",
+///   "sequence_num": 0,
+///   "events": [
+///     {
+///       "type": "snapshot",
+///       "candles": [
+///         {
+///           "start": "1688998200",
+///           "high": "1867.72",
+///           "low": "1865.63",
+///           "open": "1867.38",
+///           "close": "1866.81",
+///           "volume": "0.20269406",
+///           "product_id": "ETH-USD"
+///         }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", content  = "candles")]
+pub enum CandleEvent {
+    #[serde(rename = "snapshot")]
+    Snapshot(Vec<CBCandle>),
+    #[serde(rename = "update")]
+    Update(Vec<CBCandle>),
+}
+
+impl CandleEvent {
+    pub fn data(&self) -> &[CBCandle] {
+        match self {
+            CandleEvent::Snapshot(data) => data,
+            CandleEvent::Update(data) => data,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+struct CBCandle {
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    start: u64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    high: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    low: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+
+    open: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    close: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    volume: f64,
+    product_id: String,
+}
+
+impl Identifier<Option<SubscriptionId>> for CoinbaseInternationalMessage<CandleEvent> {
+    fn id(&self) -> Option<SubscriptionId> {
+        match self.events.first() {
+            None => None,
+            Some(first_event) => match first_event.data().first() {
+                None => None,
+                Some(candle) => {
+                    let product_id = candle.product_id.as_str();
+                    ExchangeSub::from((CoinbaseInternationalChannel::CANDLES, product_id))
+                        .id()
+                        .into()
+                }
+            },
+        }
+    }
+}
+
+impl<InstrumentKey>
+    From<(
+        ExchangeId,
+        InstrumentKey,
+        CoinbaseInternationalMessage<CandleEvent>,
+    )> for MarketIter<InstrumentKey, Candle>
+where
+    InstrumentKey: Clone,
+{
+    fn from(
+        (exchange_id, instrument, message): (
+            ExchangeId,
+            InstrumentKey,
+            CoinbaseInternationalMessage<CandleEvent>,
+        ),
+    ) -> Self {
+        let events: Vec<_> = message
+            .events
+            .iter()
+            .flat_map(|event| {
+                let data = event.data();
+                data.iter().map(|c| {
+                    Ok(MarketEvent {
+                        time_exchange: message.timestamp,
+                        time_received: Utc::now(),
+                        exchange: exchange_id,
+                        instrument: instrument.clone(),
+                        kind: Candle {
+                            // FIXME: check coinbase candle's start with barter close_time
+                            close_time: DateTime::<Utc>::from_timestamp(c.start as i64, 0).unwrap(),
+                            open: c.open,
+                            high: c.high,
+                            low: c.low,
+                            close: c.close,
+                            volume: c.volume,
+                            trade_count: 0,
+                        },
+                    })
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self(events)
+    }
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/candles.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/candles.rs
@@ -2,11 +2,11 @@ use crate::event::{MarketEvent, MarketIter};
 use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
 use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
 use crate::exchange::subscription::ExchangeSub;
-use crate::subscription::candle::{Candle, Candles};
+use crate::subscription::candle::{Candle};
 use crate::Identifier;
 use barter_instrument::exchange::ExchangeId;
 use barter_integration::subscription::SubscriptionId;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Coinbase candles WebSocket message.
@@ -129,8 +129,7 @@ where
                     })
                 })
             })
-            .collect::<Vec<_>>()
-            .into();
+            .collect::<Vec<_>>();
         Self(events)
     }
 }

--- a/barter-data/src/exchange/coinbase_advanced_trade/channel.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/channel.rs
@@ -1,0 +1,72 @@
+use super::CoinbaseInternational;
+use crate::{
+    subscription::{trade::PublicTrades, Subscription},
+    Identifier,
+};
+use serde::Serialize;
+use crate::subscription::book::{OrderBooksL1, OrderBooksL2};
+use crate::subscription::candle::Candles;
+
+/// Type that defines how to translate a Barter [`Subscription`] into a
+/// [`CoinbaseInternational`] channel to be subscribed to.
+///
+/// See docs: <https://docs.cdp.coinbase.com/advanced-trade/docs/ws-channels>
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+pub struct CoinbaseInternationalChannel(pub &'static str);
+
+impl CoinbaseInternationalChannel {
+    /// Real-time server pings to keep all connections open.
+    pub const HEARTBEATS: Self = Self("heartbeats");
+
+    /// Real-time updates on product candles.
+    pub const CANDLES: Self = Self("candles");
+
+    /// Sends all products and currencies on a preset interval.
+    pub const STATUS: Self = Self("status");
+
+    /// Real-time price updates every time a match happens.
+    pub const TICKER: Self = Self("ticker");
+
+    /// Real-time price updates every 5000 milli-seconds.
+    pub const TICKER_BATCH: Self = Self("ticker_batch");
+
+    /// All updates and easiest way to keep order book snapshot.
+    pub const LEVEL2: Self = Self("level2");
+
+    /// Only sends messages that include the authenticated user.
+    pub const USER: Self = Self("user");
+
+    /// Real-time updates every time a market trade happens.
+    pub const MARKET_TRADES: Self = Self("market_trades");
+
+    /// Real-time updates every time a user's futures balance changes.
+    pub const FUTURES_BALANCE_SUMMARY: Self = Self("futures_balance_summary");
+}
+
+impl AsRef<str> for CoinbaseInternationalChannel {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
+}
+
+impl<Instrument> Identifier<CoinbaseInternationalChannel> for Subscription<CoinbaseInternational, Instrument, PublicTrades> {
+    fn id(&self) -> CoinbaseInternationalChannel {
+        CoinbaseInternationalChannel::MARKET_TRADES
+    }
+}
+impl<Instrument> Identifier<CoinbaseInternationalChannel> for Subscription<CoinbaseInternational, Instrument, OrderBooksL1> {
+    fn id(&self) -> CoinbaseInternationalChannel {
+        CoinbaseInternationalChannel::TICKER
+    }
+}
+impl<Instrument> Identifier<CoinbaseInternationalChannel> for Subscription<CoinbaseInternational, Instrument, OrderBooksL2> {
+    fn id(&self) -> CoinbaseInternationalChannel {
+        CoinbaseInternationalChannel::LEVEL2
+    }
+}
+
+impl<Instrument> Identifier<CoinbaseInternationalChannel> for Subscription<CoinbaseInternational, Instrument, Candles> {
+    fn id(&self) -> CoinbaseInternationalChannel {
+        CoinbaseInternationalChannel::CANDLES
+    }
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/level2.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/level2.rs
@@ -5,12 +5,11 @@ use barter_integration::Side;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 use crate::event::{MarketEvent, MarketIter};
 use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
 use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
 use crate::exchange::subscription::ExchangeSub;
-use crate::subscription::book::{OrderBookEvent, OrderBooksL2};
+use crate::subscription::book::OrderBookEvent;
 use crate::Identifier;
 
 /// Coinbase level2 WebSocket message.
@@ -142,8 +141,7 @@ where
                     },
                 })
             })
-            .collect::<Vec<_>>()
-            .into();
+            .collect::<Vec<_>>();
         Self(events)
     }
 }

--- a/barter-data/src/exchange/coinbase_advanced_trade/level2.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/level2.rs
@@ -1,0 +1,149 @@
+use crate::books::OrderBook;
+use barter_instrument::exchange::ExchangeId;
+use barter_integration::subscription::SubscriptionId;
+use barter_integration::Side;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use crate::event::{MarketEvent, MarketIter};
+use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
+use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
+use crate::exchange::subscription::ExchangeSub;
+use crate::subscription::book::{OrderBookEvent, OrderBooksL2};
+use crate::Identifier;
+
+/// Coinbase level2 WebSocket message.
+/// ### Raw Payload Examples
+
+/// ```json
+/// {
+///   "channel": "l2_data",
+///   "client_id": "",
+///   "timestamp": "2023-02-09T20:32:50.714964855Z",
+///   "sequence_num": 0,
+///   "events": [
+///     {
+///       "type": "snapshot",
+///       "product_id": "BTC-USD",
+///       "updates": [
+///         {
+///           "side": "bid",
+///           "event_time": "1970-01-01T00:00:00Z",
+///           "price_level": "21921.73",
+///           "new_quantity": "0.06317902"
+///         },
+///         {
+///           "side": "bid",
+///           "event_time": "1970-01-01T00:00:00Z",
+///           "price_level": "21921.3",
+///           "new_quantity": "0.02"
+///         }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum Level2Event {
+    #[serde(rename = "snapshot")]
+    Snapshot(Level2),
+    #[serde(rename = "update")]
+    Update(Level2),
+}
+impl Level2Event {
+    pub fn is_snapshot(&self) -> bool {
+        matches!(self, Level2Event::Snapshot(_))
+    }
+    pub fn data(&self) -> &Level2 {
+        match self {
+            Level2Event::Snapshot(data) => data,
+            Level2Event::Update(data) => data,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct Level2 {
+    pub product_id: String,
+    pub updates: Vec<Level2Update>,
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct Level2Update {
+    pub side: Side,
+    pub event_time: DateTime<Utc>,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub price_level: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub new_quantity: Decimal,
+}
+
+impl Identifier<Option<SubscriptionId>> for CoinbaseInternationalMessage<Level2Event> {
+    fn id(&self) -> Option<SubscriptionId> {
+        match self.events.first() {
+            None => None,
+            Some(first_event) => {
+                let data = first_event.data();
+                let product_id = data.product_id.as_str();
+                ExchangeSub::from((CoinbaseInternationalChannel::LEVEL2, product_id))
+                    .id()
+                    .into()
+            }
+        }
+    }
+}
+
+impl<InstrumentKey>
+    From<(
+        ExchangeId,
+        InstrumentKey,
+        CoinbaseInternationalMessage<Level2Event>,
+    )> for MarketIter<InstrumentKey, OrderBookEvent>
+where
+    InstrumentKey: Clone,
+{
+    fn from(
+        (exchange_id, instrument, message): (
+            ExchangeId,
+            InstrumentKey,
+            CoinbaseInternationalMessage<Level2Event>,
+        ),
+    ) -> Self {
+        let events: Vec<_> = message
+            .events
+            .iter()
+            .map(|event| {
+                let data = event.data();
+                // all updates have the same event_time
+                let event_time = data.updates.first().map(|u| u.event_time).unwrap_or(message.timestamp);
+                let order_book = OrderBook::new(
+                    message.sequence_num,
+                    Some(event_time),
+                    data.updates
+                        .iter()
+                        .filter(|u| u.side == Side::Buy)
+                        .map(move |update| (update.price_level, update.new_quantity)),
+                    data.updates
+                        .iter()
+                        .filter(|u| u.side == Side::Sell)
+                        .map(move |update| (update.price_level, update.new_quantity)),
+                );
+                Ok(MarketEvent {
+                    time_exchange: message.timestamp,
+                    time_received: Utc::now(),
+                    exchange: exchange_id,
+                    instrument: instrument.clone(),
+                    kind: if event.is_snapshot() {
+                        OrderBookEvent::Snapshot(order_book)
+                    } else {
+                        OrderBookEvent::Update(order_book)
+                    },
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self(events)
+    }
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/market.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/market.rs
@@ -1,0 +1,46 @@
+use super::CoinbaseInternational;
+use crate::{
+    subscription::Subscription,
+    Identifier,
+};
+use serde::Serialize;
+use smol_str::{format_smolstr, SmolStr, StrExt};
+use barter_instrument::asset::name::AssetNameInternal;
+use barter_instrument::instrument::market_data::MarketDataInstrument;
+use barter_instrument::Keyed;
+use crate::instrument::MarketInstrumentData;
+
+/// Type that defines how to translate a Barter [`Subscription`] into a
+/// [`CoinbaseInternational`] market to be subscribed to.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+pub struct CoinbaseInternationalMarket(pub SmolStr);
+
+impl<Kind> Identifier<CoinbaseInternationalMarket> for Subscription<CoinbaseInternational, MarketDataInstrument, Kind> {
+    fn id(&self) -> CoinbaseInternationalMarket {
+        coinbase_market(&self.instrument.base, &self.instrument.quote)
+    }
+}
+
+impl<InstrumentKey, Kind> Identifier<CoinbaseInternationalMarket>
+for Subscription<CoinbaseInternational, Keyed<InstrumentKey, MarketDataInstrument>, Kind>
+{
+    fn id(&self) -> CoinbaseInternationalMarket {
+        coinbase_market(&self.instrument.value.base, &self.instrument.value.quote)
+    }
+}
+
+impl<Kind> Identifier<CoinbaseInternationalMarket> for Subscription<CoinbaseInternational, MarketInstrumentData, Kind> {
+    fn id(&self) -> CoinbaseInternationalMarket {
+        CoinbaseInternationalMarket(self.instrument.name_exchange.clone())
+    }
+}
+
+impl AsRef<str> for CoinbaseInternationalMarket {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+fn coinbase_market(base: &AssetNameInternal, quote: &AssetNameInternal) -> CoinbaseInternationalMarket {
+    CoinbaseInternationalMarket(format_smolstr!("{base}-{quote}").to_uppercase_smolstr())
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/market_trades.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/market_trades.rs
@@ -1,0 +1,154 @@
+use super::CoinbaseChannel;
+use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
+use crate::subscription::candle::{Candle, Candles};
+use crate::{
+    event::{MarketEvent, MarketIter},
+    exchange::ExchangeSub,
+    subscription::trade::PublicTrade,
+    Identifier,
+};
+use barter_instrument::exchange::ExchangeId;
+use barter_integration::{subscription::SubscriptionId, Side};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
+
+/// Coinbase real-time trade WebSocket message.
+///
+/// ### Raw Payload Examples
+/// See docs: <https://docs.cdp.coinbase.com/advanced-trade/docs/ws-channels#market-trades-channel>
+/// ```json
+///   "client_id": "",
+///   "timestamp": "2023-02-09T20:19:35.39625135Z",
+///   "sequence_num": 0,
+///   "events": [
+///     {
+///       "type": "snapshot",
+///       "trades": [
+///         {
+///           "trade_id": "000000000",
+///           "product_id": "ETH-USD",
+///           "price": "1260.01",
+///           "size": "0.3",
+///           "side": "BUY",
+///           "time": "2019-08-14T20:42:27.265Z"
+///         }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", content = "trades")]
+pub enum MarketTradeEvent {
+    #[serde(rename = "snapshot")]
+    Snapshot(Vec<Trade>),
+    #[serde(rename = "update")]
+    Update(Vec<Trade>),
+}
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct Trade {
+    trade_id: String,
+    product_id: String,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    price: f64,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    size: f64,
+    side: Side,
+    time: DateTime<Utc>,
+}
+
+impl Identifier<Option<SubscriptionId>> for CoinbaseInternationalMessage<MarketTradeEvent> {
+    fn id(&self) -> Option<SubscriptionId> {
+        match self.events.first() {
+            None => None,
+            Some(first_event) => {
+                let trade = match first_event {
+                    MarketTradeEvent::Snapshot(trades) => trades,
+                    MarketTradeEvent::Update(trades) => trades,
+                }.first();
+                match trade {
+                    None => {
+                        None
+                    }
+                    Some(trade) => {
+                        let product_id = trade.product_id.as_str();
+                        ExchangeSub::from((self.channel.as_str(), product_id))
+                            .id()
+                            .into()
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<InstrumentKey>
+    From<(
+        ExchangeId,
+        InstrumentKey,
+        CoinbaseInternationalMessage<MarketTradeEvent>,
+    )> for MarketIter<InstrumentKey, PublicTrade>
+where InstrumentKey: Clone {
+    fn from(
+        (exchange_id, instrument, trade): (
+            ExchangeId,
+            InstrumentKey,
+            CoinbaseInternationalMessage<MarketTradeEvent>,
+        ),
+    ) -> Self {
+        let events: Vec<_> = trade
+            .events
+            .iter()
+            .flat_map(|event| match event {
+                MarketTradeEvent::Snapshot(snapshot) => snapshot
+                    .iter()
+                    .map(|trade| {
+                        Ok(MarketEvent {
+                            time_exchange: trade.time,
+                            time_received: Utc::now(),
+                            exchange: exchange_id,
+                            instrument: instrument.clone(),
+                            kind: PublicTrade {
+                                id: trade.trade_id.clone(),
+                                price: trade.price,
+                                amount: trade.size,
+                                side: trade.side,
+                            },
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+                MarketTradeEvent::Update(update) => update
+                    .iter()
+                    .map(|trade| {
+                        Ok(MarketEvent {
+                            time_exchange: trade.time,
+                            time_received: Utc::now(),
+                            exchange: exchange_id,
+                            instrument: instrument.clone(),
+                            kind: PublicTrade {
+                                id: trade.trade_id.clone(),
+                                price: trade.price,
+                                amount: trade.size,
+                                side: trade.side,
+                            },
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self(events)
+    }
+}
+
+/// Deserialize a [`MarketTradeEvent`] "product_id" (eg/ "BTC-USD") as the associated [`SubscriptionId`]
+/// (eg/ SubscriptionId("matches|BTC-USD").
+pub fn de_trade_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    <&str as Deserialize>::deserialize(deserializer).map(|product_id| {
+        ExchangeSub::from((CoinbaseInternationalChannel::MARKET_TRADES, product_id)).id()
+    })
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/market_trades.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/market_trades.rs
@@ -1,6 +1,4 @@
-use super::CoinbaseChannel;
 use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
-use crate::subscription::candle::{Candle, Candles};
 use crate::{
     event::{MarketEvent, MarketIter},
     exchange::ExchangeSub,
@@ -136,8 +134,7 @@ where InstrumentKey: Clone {
                     })
                     .collect::<Vec<_>>(),
             })
-            .collect::<Vec<_>>()
-            .into();
+            .collect::<Vec<_>>();
         Self(events)
     }
 }

--- a/barter-data/src/exchange/coinbase_advanced_trade/message.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/message.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct CoinbaseInternationalMessage<Event> {
+    pub channel: String,
+    pub client_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub sequence_num: u64,
+    pub events: Vec<Event>,
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/mod.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/mod.rs
@@ -11,7 +11,6 @@ use barter_integration::{error::SocketError, protocol::websocket::WsMessage};
 use barter_macro::{DeExchange, SerExchange};
 use serde_json::json;
 use url::Url;
-use crate::exchange::coinbase::channel::CoinbaseChannel;
 use crate::exchange::coinbase_advanced_trade::candles::CandleEvent;
 use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
 use crate::exchange::coinbase_advanced_trade::level2::Level2Event;
@@ -20,7 +19,7 @@ use crate::exchange::coinbase_advanced_trade::market_trades::{MarketTradeEvent};
 use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
 use crate::exchange::coinbase_advanced_trade::subscription::CoinbaseInternationalSubResponse;
 use crate::exchange::coinbase_advanced_trade::ticker::TickerEvent;
-use crate::subscription::book::{OrderBookL1, OrderBooksL1, OrderBooksL2};
+use crate::subscription::book::{OrderBooksL1, OrderBooksL2};
 use crate::subscription::candle::Candles;
 
 pub mod channel;

--- a/barter-data/src/exchange/coinbase_advanced_trade/mod.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/mod.rs
@@ -1,0 +1,112 @@
+use crate::{
+    exchange::{Connector, ExchangeSub, StreamSelector},
+    instrument::InstrumentData,
+    subscriber::{validator::WebSocketSubValidator, WebSocketSubscriber},
+    subscription::trade::PublicTrades,
+    transformer::stateless::StatelessTransformer,
+    ExchangeWsStream, NoInitialSnapshots,
+};
+use barter_instrument::exchange::ExchangeId;
+use barter_integration::{error::SocketError, protocol::websocket::WsMessage};
+use barter_macro::{DeExchange, SerExchange};
+use serde_json::json;
+use url::Url;
+use crate::exchange::coinbase::channel::CoinbaseChannel;
+use crate::exchange::coinbase_advanced_trade::candles::CandleEvent;
+use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
+use crate::exchange::coinbase_advanced_trade::level2::Level2Event;
+use crate::exchange::coinbase_advanced_trade::market::CoinbaseInternationalMarket;
+use crate::exchange::coinbase_advanced_trade::market_trades::{MarketTradeEvent};
+use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
+use crate::exchange::coinbase_advanced_trade::subscription::CoinbaseInternationalSubResponse;
+use crate::exchange::coinbase_advanced_trade::ticker::TickerEvent;
+use crate::subscription::book::{OrderBookL1, OrderBooksL1, OrderBooksL2};
+use crate::subscription::candle::Candles;
+
+pub mod channel;
+pub mod market;
+pub mod subscription;
+pub mod message;
+mod market_trades;
+mod ticker;
+mod level2;
+mod candles;
+/// \[`CoinbaseInternational`\] server base url.
+///
+/// See docs: <https://docs.cdp.coinbase.com/advanced-trade/docs/ws-overview>
+pub const BASE_URL_COINBASE_INTERNATIONAL: &str = "wss://advanced-trade-ws.coinbase.com";
+
+/// \[`CoinbaseInternational`\] exchange.
+///
+/// See docs: <https://docs.cdp.coinbase.com/advanced-trade/docs/ws-overview>
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, DeExchange, SerExchange,
+)]
+pub struct CoinbaseInternational;
+
+impl Connector for CoinbaseInternational {
+    const ID: ExchangeId = ExchangeId::CoinbaseInternational;
+    type Channel = CoinbaseInternationalChannel;
+    type Market = CoinbaseInternationalMarket;
+    type Subscriber = WebSocketSubscriber;
+    type SubValidator = WebSocketSubValidator;
+    type SubResponse = CoinbaseInternationalSubResponse;
+
+    fn url() -> Result<Url, SocketError> {
+        Url::parse(BASE_URL_COINBASE_INTERNATIONAL).map_err(SocketError::UrlParse)
+    }
+
+    fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
+        exchange_subs
+            .into_iter()
+            .map(|ExchangeSub { channel, market }| {
+                WsMessage::Text(
+                    json!({
+                        "type": "subscribe",
+                        "product_ids": [market.as_ref()],
+                        "channel": channel.as_ref(),
+                    })
+                        .to_string(),
+                )
+            })
+            .collect()
+    }
+}
+
+impl<Instrument> StreamSelector<Instrument, PublicTrades> for CoinbaseInternational
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+    ExchangeWsStream<StatelessTransformer<Self, Instrument::Key, PublicTrades, CoinbaseInternationalMessage<MarketTradeEvent>>>;
+}
+
+
+impl<Instrument> StreamSelector<Instrument, OrderBooksL1> for CoinbaseInternational
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+    ExchangeWsStream<StatelessTransformer<Self, Instrument::Key, OrderBooksL1, CoinbaseInternationalMessage<TickerEvent>>>;
+}
+
+
+impl<Instrument> StreamSelector<Instrument, OrderBooksL2> for CoinbaseInternational
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+    ExchangeWsStream<StatelessTransformer<Self, Instrument::Key, OrderBooksL2, CoinbaseInternationalMessage<Level2Event>>>;
+}
+
+impl<Instrument> StreamSelector<Instrument, Candles> for CoinbaseInternational
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+    ExchangeWsStream<StatelessTransformer<Self, Instrument::Key, Candles, CoinbaseInternationalMessage<CandleEvent>>>;
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/subscription.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/subscription.rs
@@ -1,0 +1,43 @@
+use std::collections::BTreeMap;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use barter_integration::Validator;
+
+/// Response type for a [`CoinbaseInternational`] subscription.
+/// Example:
+/// {
+///     "channel": "subscriptions",
+///     "client_id": "",
+///     "timestamp": "2024-12-20T02:52:29.787710914Z",
+///     "sequence_num": 1,
+///     "events": [
+///         {
+///             "subscriptions": {
+///                 "ticker_batch": ["EURC-USDC"]
+///             }
+///         }
+///     ]
+/// }
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+pub struct CoinbaseInternationalSubResponse {
+    pub channel: String,
+    pub timestamp: DateTime<Utc>,
+    pub events: Vec<SubscriptionEvent>,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+pub struct SubscriptionEvent {
+    pub subscriptions: BTreeMap<String, Vec<String>>,
+}
+
+impl Validator for CoinbaseInternationalSubResponse {
+    fn validate(self) -> Result<Self, barter_integration::error::SocketError> {
+        if self.channel == "subscriptions" {
+            Ok(self)
+        } else {
+            Err(barter_integration::error::SocketError::Subscribe(
+                format!("Unexpected response type: {}", self.channel),
+            ))
+        }
+    }
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/ticker.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/ticker.rs
@@ -1,0 +1,152 @@
+use crate::books::Level;
+use crate::event::{MarketEvent, MarketIter};
+use crate::exchange::coinbase_advanced_trade::message::CoinbaseInternationalMessage;
+use crate::exchange::subscription::ExchangeSub;
+use crate::subscription::book::OrderBookL1;
+use crate::Identifier;
+use barter_instrument::exchange::ExchangeId;
+use barter_integration::subscription::SubscriptionId;
+use chrono::Utc;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use crate::exchange::coinbase_advanced_trade::channel::CoinbaseInternationalChannel;
+
+/// Coinbase ticker WebSocket message.
+/// ### Raw Payload Examples
+
+/// ```json
+/// {
+///   "channel": "ticker",
+///   "client_id": "",
+///   "timestamp": "2023-02-09T20:30:37.167359596Z",
+///   "sequence_num": 0,
+///   "events": [
+///     {
+///       "type": "snapshot",
+///       "tickers": [
+///         {
+///           "type": "ticker",
+///           "product_id": "BTC-USD",
+///           "price": "21932.98",
+///           "volume_24_h": "16038.28770938",
+///           "low_24_h": "21835.29",
+///           "high_24_h": "23011.18",
+///           "low_52_w": "15460",
+///           "high_52_w": "48240",
+///           "price_percent_chg_24_h": "-4.15775596190603",
+///           "best_bid": "21931.98",
+///           "best_bid_quantity": "8000.21",
+///           "best_ask": "21933.98",
+///           "best_ask_quantity": "8038.07770938"
+///         }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", content = "tickers")]
+pub enum TickerEvent {
+    #[serde(rename = "snapshot")]
+    Snapshot(Vec<Ticker>),
+    #[serde(rename = "update")]
+    Update(Vec<Ticker>),
+}
+impl TickerEvent {
+    pub fn tickers(&self) -> &[Ticker] {
+        match self {
+            TickerEvent::Snapshot(tickers) => tickers,
+            TickerEvent::Update(tickers) => tickers,
+        }
+    }
+}
+#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct Ticker {
+    pub product_id: String,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub price: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub volume_24_h: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub low_24_h: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub high_24_h: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub low_52_w: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub high_52_w: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub best_bid: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub best_bid_quantity: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub best_ask: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub best_ask_quantity: Decimal,
+    #[serde(deserialize_with = "barter_integration::de::de_str")]
+    pub price_percent_chg_24_h: f64,
+}
+
+impl Identifier<Option<SubscriptionId>> for CoinbaseInternationalMessage<TickerEvent> {
+    fn id(&self) -> Option<SubscriptionId> {
+        match self.events.first() {
+            None => None,
+            Some(first_event) => {
+                let ticker = first_event.tickers().first();
+                match ticker {
+                    None => None,
+                    Some(ticker) => {
+                        let product_id = ticker.product_id.as_str();
+                        ExchangeSub::from((CoinbaseInternationalChannel::TICKER.as_ref(), product_id))
+                            .id()
+                            .into()
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<InstrumentKey>
+    From<(
+        ExchangeId,
+        InstrumentKey,
+        CoinbaseInternationalMessage<TickerEvent>,
+    )> for MarketIter<InstrumentKey, OrderBookL1>
+where
+    InstrumentKey: Clone,
+{
+    fn from(
+        (exchange_id, instrument, message): (
+            ExchangeId,
+            InstrumentKey,
+            CoinbaseInternationalMessage<TickerEvent>,
+        ),
+    ) -> Self {
+        let events: Vec<_> = message
+            .events
+            .iter()
+            .flat_map(|event| {
+                event.tickers().iter().map(|ticker| {
+                    Ok(MarketEvent {
+                        time_exchange: message.timestamp,
+                        time_received: Utc::now(),
+                        exchange: exchange_id,
+                        instrument: instrument.clone(),
+                        kind: OrderBookL1 {
+                            last_update_time: message.timestamp,
+                            best_bid: Level::new(ticker.best_bid, ticker.best_bid_quantity),
+                            best_ask: Level {
+                                price: ticker.best_ask,
+                                amount: ticker.best_ask_quantity,
+                            },
+                        },
+                    })
+                })
+            })
+            .collect::<Vec<_>>()
+            .into();
+        Self(events)
+    }
+}

--- a/barter-data/src/exchange/coinbase_advanced_trade/ticker.rs
+++ b/barter-data/src/exchange/coinbase_advanced_trade/ticker.rs
@@ -145,8 +145,7 @@ where
                     })
                 })
             })
-            .collect::<Vec<_>>()
-            .into();
+            .collect::<Vec<_>>();
         Self(events)
     }
 }

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -26,6 +26,9 @@ pub mod bybit;
 /// `Coinbase` [`Connector`] and [`StreamSelector`] implementations.
 pub mod coinbase;
 
+/// `CoinbaseAdvancedTrade` [`Connector`] and [`StreamSelector`] implementations.
+pub mod coinbase_advanced_trade;
+
 /// `GateioSpot`, `GateioFuturesUsd` & `GateioFuturesBtc` [`Connector`] and [`StreamSelector`]
 /// implementations.
 pub mod gateio;

--- a/barter-data/src/subscriber/validator.rs
+++ b/barter-data/src/subscriber/validator.rs
@@ -96,7 +96,7 @@ impl SubscriptionValidator for WebSocketSubValidator {
                             // Subscription failure
                             Err(err) => break Err(err)
                         }
-                        Some(Err(SocketError::Deserialise { error: _, payload })) if success_responses >= 1 => {
+                        Some(Err(SocketError::Deserialise { error: _, payload }))  => {
                             // Most likely already active subscription payload, so add to market
                             // event buffer for post validation processing
                             buff_active_subscription_events.push(WsMessage::Text(payload));

--- a/barter-integration/src/lib.rs
+++ b/barter-integration/src/lib.rs
@@ -164,9 +164,9 @@ where
 /// [`Side`] of a trade or position - Buy or Sell.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub enum Side {
-    #[serde(alias = "buy", alias = "BUY", alias = "b")]
+    #[serde(alias = "buy", alias = "BUY", alias = "b", alias = "bid")]
     Buy,
-    #[serde(alias = "sell", alias = "SELL", alias = "s")]
+    #[serde(alias = "sell", alias = "SELL", alias = "s", alias = "ask", alias="offer")]
     Sell,
 }
 


### PR DESCRIPTION
I'm tring to add the new coinbase api which described here https://docs.cdp.coinbase.com/advanced-trade/docs/ws-overview.

I have manually tested the code, it looks ok.
but I cannot match  the `start` field of coinbase's candle  to the `close_time` of candle defined in barter.
any suggestions?