### PR TITLE
feat: orderbookl2 optional best levels

### DIFF
--- a/barter-data/src/books/mod.rs
+++ b/barter-data/src/books/mod.rs
@@ -324,7 +324,7 @@ mod tests {
         fn test_mid_price() {
             struct TestCase {
                 input: OrderBookL1,
-                expected: Decimal,
+                expected: Option<Decimal>,
             }
 
             let tests = vec![
@@ -332,28 +332,46 @@ mod tests {
                     // TC0
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(100, 999999),
-                        best_ask: Level::new(200, 1),
+                        best_bid: Some(Level::new(100, 999999)),
+                        best_ask: Some(Level::new(200, 1)),
                     },
-                    expected: dec!(150.0),
+                    expected: Some(dec!(150.0)),
                 },
                 TestCase {
                     // TC1
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(50, 1),
-                        best_ask: Level::new(250, 999999),
+                        best_bid: Some(Level::new(50, 1)),
+                        best_ask: Some(Level::new(250, 999999)),
                     },
-                    expected: dec!(150.0),
+                    expected: Some(dec!(150.0)),
                 },
                 TestCase {
                     // TC2
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(10, 999999),
-                        best_ask: Level::new(250, 999999),
+                        best_bid: Some(Level::new(10, 999999)),
+                        best_ask: Some(Level::new(250, 999999)),
                     },
-                    expected: dec!(130.0),
+                    expected: Some(dec!(130.0)),
+                },
+                TestCase {
+                    // TC3
+                    input: OrderBookL1 {
+                        last_update_time: Default::default(),
+                        best_bid: Some(Level::new(10, 999999)),
+                        best_ask: None,
+                    },
+                    expected: None,
+                },
+                TestCase {
+                    // TC4
+                    input: OrderBookL1 {
+                        last_update_time: Default::default(),
+                        best_bid: None,
+                        best_ask: Some(Level::new(250, 999999)),
+                    },
+                    expected: None,
                 },
             ];
 
@@ -366,7 +384,7 @@ mod tests {
         fn test_volume_weighted_mid_price() {
             struct TestCase {
                 input: OrderBookL1,
-                expected: Decimal,
+                expected: Option<Decimal>,
             }
 
             let tests = vec![
@@ -374,28 +392,46 @@ mod tests {
                     // TC0: volume the same so should be equal to non-weighted mid price
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(100, 100),
-                        best_ask: Level::new(200, 100),
+                        best_bid: Some(Level::new(100, 100)),
+                        best_ask: Some(Level::new(200, 100)),
                     },
-                    expected: dec!(150.0),
+                    expected: Some(dec!(150.0)),
                 },
                 TestCase {
                     // TC1: volume affects mid-price
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(100, 600),
-                        best_ask: Level::new(200, 1000),
+                        best_bid: Some(Level::new(100, 600)),
+                        best_ask: Some(Level::new(200, 1000)),
                     },
-                    expected: dec!(137.5),
+                    expected: Some(dec!(137.5)),
                 },
                 TestCase {
                     // TC2: volume the same and price the same
                     input: OrderBookL1 {
                         last_update_time: Default::default(),
-                        best_bid: Level::new(1000, 999999),
-                        best_ask: Level::new(1000, 999999),
+                        best_bid: Some(Level::new(1000, 999999)),
+                        best_ask: Some(Level::new(1000, 999999)),
                     },
-                    expected: dec!(1000.0),
+                    expected: Some(dec!(1000.0)),
+                },
+                TestCase {
+                    // TC3: best ask is None
+                    input: OrderBookL1 {
+                        last_update_time: Default::default(),
+                        best_bid: Some(Level::new(1000, 999999)),
+                        best_ask: None,
+                    },
+                    expected: None,
+                },
+                TestCase {
+                    // TC4: best bid is None
+                    input: OrderBookL1 {
+                        last_update_time: Default::default(),
+                        best_bid: None,
+                        best_ask: Some(Level::new(1000, 999999)),
+                    },
+                    expected: None,
                 },
             ];
 

--- a/barter-data/src/exchange/binance/book/l1.rs
+++ b/barter-data/src/exchange/binance/book/l1.rs
@@ -71,6 +71,18 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceOrderBookL1)>
     fn from(
         (exchange_id, instrument, book): (ExchangeId, InstrumentKey, BinanceOrderBookL1),
     ) -> Self {
+        let best_ask = if book.best_ask_price.is_zero() {
+            None
+        } else {
+            Some(Level::new(book.best_ask_price, book.best_ask_amount))
+        };
+
+        let best_bid = if book.best_bid_price.is_zero() {
+            None
+        } else {
+            Some(Level::new(book.best_bid_price, book.best_bid_amount))
+        };
+
         Self(vec![Ok(MarketEvent {
             time_exchange: book.time,
             time_received: Utc::now(),
@@ -78,8 +90,8 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceOrderBookL1)>
             instrument,
             kind: OrderBookL1 {
                 last_update_time: book.time,
-                best_bid: Level::new(book.best_bid_price, book.best_bid_amount),
-                best_ask: Level::new(book.best_ask_price, book.best_ask_amount),
+                best_bid,
+                best_ask,
             },
         })])
     }

--- a/barter-data/src/subscription/book.rs
+++ b/barter-data/src/subscription/book.rs
@@ -35,24 +35,30 @@ impl Display for OrderBooksL1 {
 )]
 pub struct OrderBookL1 {
     pub last_update_time: DateTime<Utc>,
-    pub best_bid: Level,
-    pub best_ask: Level,
+    pub best_bid: Option<Level>,
+    pub best_ask: Option<Level>,
 }
 
 impl OrderBookL1 {
     /// Calculate the mid-price by taking the average of the best bid and ask prices.
     ///
     /// See Docs: <https://www.quantstart.com/articles/high-frequency-trading-ii-limit-order-book>
-    pub fn mid_price(&self) -> Decimal {
-        mid_price(self.best_bid.price, self.best_ask.price)
+    pub fn mid_price(&self) -> Option<Decimal> {
+        match (self.best_ask, self.best_bid) {
+            (Some(best_ask), Some(best_bid)) => Some(mid_price(best_bid.price, best_ask.price)),
+            _ => None,
+        }
     }
 
     /// Calculate the volume weighted mid-price (micro-price), weighing the best bid and ask prices
     /// with their associated amount.
     ///
     /// See Docs: <https://www.quantstart.com/articles/high-frequency-trading-ii-limit-order-book>
-    pub fn volume_weighed_mid_price(&self) -> Decimal {
-        volume_weighted_mid_price(self.best_bid, self.best_ask)
+    pub fn volume_weighed_mid_price(&self) -> Option<Decimal> {
+        match (self.best_ask, self.best_bid) {
+            (Some(best_ask), Some(best_bid)) => Some(volume_weighted_mid_price(best_bid, best_ask)),
+            _ => None,
+        }
     }
 }
 

--- a/barter/src/engine/state/instrument/market_data.rs
+++ b/barter/src/engine/state/instrument/market_data.rs
@@ -48,13 +48,9 @@ impl<InstrumentKey> MarketDataState<InstrumentKey> for DefaultMarketData {
     type EventKind = DataKind;
 
     fn price(&self) -> Option<Decimal> {
-        if self.l1.best_bid.price == Decimal::default()
-            || self.l1.best_ask.price == Decimal::default()
-        {
-            self.last_traded_price.as_ref().map(|timed| timed.value)
-        } else {
-            Some(self.l1.volume_weighed_mid_price())
-        }
+        self.l1
+            .volume_weighed_mid_price()
+            .or(self.last_traded_price.as_ref().map(|timed| timed.value))
     }
 }
 


### PR DESCRIPTION
Make best levels optional in case when there is no liquidity on single or both sides of the book.