### PR TITLE
Switched reqwest to rustls-tls

### DIFF
--- a/barter-data/Cargo.toml
+++ b/barter-data/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = { workspace = true }
 
 # Protocol
 url = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 
 # Error
 thiserror = { workspace = true }


### PR DESCRIPTION
Replaced OpenSSL b enabling the rust-tls flags in reuest.
 
Resolves https://github.com/barter-rs/barter-rs/issues/64

I had a look at all dependencies; first of all thank you for properly handling the bulk of deps in the workdpace Cargo.toml; that made my life a lot easier. I am still crawling through each crate, one by one, to find potential implicit OpenSSL deps.

However, build, test, and docs all pass locally so it seems that, at least on my branch, nothing was broken. 

In the meantime, it would be great to do a full CI run to see if any issue arises. 

Signed-off-by: Marvin Hansen <marvin.hansen@gmail.com>