### PR TITLE
feat: add executed_at to PublicTrade

### DIFF
--- a/barter-data/src/exchange/binance/trade.rs
+++ b/barter-data/src/exchange/binance/trade.rs
@@ -87,6 +87,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceTrade)>
             instrument,
             kind: PublicTrade {
                 id: trade.id.to_string(),
+                time_executed: trade.time,
                 price: trade.price,
                 amount: trade.amount,
                 side: trade.side,

--- a/barter-data/src/exchange/bitfinex/trade.rs
+++ b/barter-data/src/exchange/bitfinex/trade.rs
@@ -53,6 +53,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BitfinexTrade)>
             instrument,
             kind: PublicTrade {
                 id: trade.id.to_string(),
+                time_executed: trade.time,
                 price: trade.price,
                 amount: trade.amount,
                 side: trade.side,

--- a/barter-data/src/exchange/bitmex/trade.rs
+++ b/barter-data/src/exchange/bitmex/trade.rs
@@ -63,6 +63,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, BitmexTrade)>
                         instrument: instrument.clone(),
                         kind: PublicTrade {
                             id: trade.id,
+                            time_executed: trade.timestamp,
                             price: trade.price,
                             amount: trade.amount,
                             side: trade.side,

--- a/barter-data/src/exchange/bybit/trade.rs
+++ b/barter-data/src/exchange/bybit/trade.rs
@@ -65,6 +65,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, BybitTrade)>
                         instrument: instrument.clone(),
                         kind: PublicTrade {
                             id: trade.id,
+                            time_executed: trade.time,
                             price: trade.price,
                             amount: trade.amount,
                             side: trade.side,

--- a/barter-data/src/exchange/coinbase/trade.rs
+++ b/barter-data/src/exchange/coinbase/trade.rs
@@ -60,6 +60,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, CoinbaseTrade)>
             instrument,
             kind: PublicTrade {
                 id: trade.id.to_string(),
+                time_executed: trade.time,
                 price: trade.price,
                 amount: trade.amount,
                 side: trade.side,

--- a/barter-data/src/exchange/gateio/perpetual/trade.rs
+++ b/barter-data/src/exchange/gateio/perpetual/trade.rs
@@ -84,6 +84,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateioFuturesTrades)
                     instrument: instrument.clone(),
                     kind: PublicTrade {
                         id: trade.id.to_string(),
+                        time_executed: trade.time,
                         price: trade.price,
                         amount: trade.amount,
                         side: if trade.amount.is_sign_positive() {

--- a/barter-data/src/exchange/gateio/spot/trade.rs
+++ b/barter-data/src/exchange/gateio/spot/trade.rs
@@ -67,6 +67,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateioSpotTrade)>
             instrument,
             kind: PublicTrade {
                 id: trade.data.id.to_string(),
+                time_executed: trade.data.time,
                 price: trade.data.price,
                 amount: trade.data.amount,
                 side: trade.data.side,

--- a/barter-data/src/exchange/kraken/trade.rs
+++ b/barter-data/src/exchange/kraken/trade.rs
@@ -74,6 +74,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, KrakenTrades)>
                         instrument: instrument.clone(),
                         kind: PublicTrade {
                             id: custom_kraken_trade_id(&trade),
+                            time_executed: trade.time,
                             price: trade.price,
                             amount: trade.amount,
                             side: trade.side,

--- a/barter-data/src/exchange/okx/trade.rs
+++ b/barter-data/src/exchange/okx/trade.rs
@@ -107,6 +107,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, OkxTrades)>
                     instrument: instrument.clone(),
                     kind: PublicTrade {
                         id: trade.id,
+                        time_executed: trade.time,
                         price: trade.price,
                         amount: trade.amount,
                         side: trade.side,

--- a/barter-data/src/lib.rs
+++ b/barter-data/src/lib.rs
@@ -394,6 +394,7 @@ pub mod test_utils {
             instrument,
             kind: DataKind::Trade(PublicTrade {
                 id: "trade_id".to_string(),
+                time_executed: time_exchange,
                 price,
                 amount: quantity,
                 side: Side::Buy,

--- a/barter-data/src/subscription/trade.rs
+++ b/barter-data/src/subscription/trade.rs
@@ -1,6 +1,7 @@
 use super::SubscriptionKind;
 use barter_instrument::Side;
 use barter_macro::{DeSubKind, SerSubKind};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`PublicTrade`]
@@ -28,6 +29,7 @@ impl std::fmt::Display for PublicTrades {
 #[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct PublicTrade {
     pub id: String,
+    pub time_executed: DateTime<Utc>,
     pub price: f64,
     pub amount: f64,
     pub side: Side,

--- a/barter/examples/data/binance_spot_market_data_with_disconnect_events.json
+++ b/barter/examples/data/binance_spot_market_data_with_disconnect_events.json
@@ -9,6 +9,7 @@
         "kind": {
           "Trade": {
             "id": "4314349047",
+            "time_executed": "2024-12-20T19:05:18.175Z",
             "price": 96962.51,
             "amount": 0.00006,
             "side": "Buy"
@@ -27,6 +28,7 @@
         "kind": {
           "Trade": {
             "id": "4314349048",
+            "time_executed": "2024-12-20T19:05:18.175Z",
             "price": 96962.51,
             "amount": 0.00008,
             "side": "Buy"
@@ -45,6 +47,7 @@
         "kind": {
           "Trade": {
             "id": "4314349049",
+            "time_executed": "2024-12-20T19:05:18.175Z",
             "price": 96962.51,
             "amount": 0.00386,
             "side": "Buy"
@@ -63,6 +66,7 @@
         "kind": {
           "Trade": {
             "id": "4314349050",
+            "time_executed": "2024-12-20T19:05:18.178Z",
             "price": 96962.51,
             "amount": 0.00103,
             "side": "Buy"
@@ -81,6 +85,7 @@
         "kind": {
           "Trade": {
             "id": "902042153",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.053,
             "side": "Buy"
@@ -102,6 +107,7 @@
         "kind": {
           "Trade": {
             "id": "902042154",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.054,
             "side": "Buy"
@@ -120,6 +126,7 @@
         "kind": {
           "Trade": {
             "id": "902042155",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.041,
             "side": "Buy"
@@ -138,6 +145,7 @@
         "kind": {
           "Trade": {
             "id": "902042156",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.038,
             "side": "Buy"
@@ -156,6 +164,7 @@
         "kind": {
           "Trade": {
             "id": "902042157",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.028,
             "side": "Buy"
@@ -174,6 +183,7 @@
         "kind": {
           "Trade": {
             "id": "902042158",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.85,
             "amount": 0.035,
             "side": "Buy"
@@ -195,6 +205,7 @@
         "kind": {
           "Trade": {
             "id": "902042159",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.053,
             "side": "Buy"
@@ -213,6 +224,7 @@
         "kind": {
           "Trade": {
             "id": "902042160",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.027,
             "side": "Buy"
@@ -231,6 +243,7 @@
         "kind": {
           "Trade": {
             "id": "902042161",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.035,
             "side": "Buy"
@@ -249,6 +262,7 @@
         "kind": {
           "Trade": {
             "id": "902042162",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.037,
             "side": "Buy"
@@ -270,6 +284,7 @@
         "kind": {
           "Trade": {
             "id": "902042163",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.035,
             "side": "Buy"
@@ -288,6 +303,7 @@
         "kind": {
           "Trade": {
             "id": "902042164",
+            "time_executed": "2024-12-20T19:05:18.196Z",
             "price": 190.86,
             "amount": 0.028,
             "side": "Buy"
@@ -306,6 +322,7 @@
         "kind": {
           "Trade": {
             "id": "4314349051",
+            "time_executed": "2024-12-20T19:05:18.197Z",
             "price": 96962.51,
             "amount": 0.00008,
             "side": "Buy"
@@ -324,6 +341,7 @@
         "kind": {
           "Trade": {
             "id": "4314349052",
+            "time_executed": "2024-12-20T19:05:18.197Z",
             "price": 96962.51,
             "amount": 0.00006,
             "side": "Buy"
@@ -342,6 +360,7 @@
         "kind": {
           "Trade": {
             "id": "4314349053",
+            "time_executed": "2024-12-20T19:05:18.197Z",
             "price": 96962.51,
             "amount": 0.00008,
             "side": "Buy"
@@ -360,6 +379,7 @@
         "kind": {
           "Trade": {
             "id": "4314349054",
+            "time_executed": "2024-12-20T19:05:18.197Z",
             "price": 96962.51,
             "amount": 0.00008,
             "side": "Buy"
@@ -378,6 +398,7 @@
         "kind": {
           "Trade": {
             "id": "4314349055",
+            "time_executed": "2024-12-20T19:05:18.197Z",
             "price": 96962.51,
             "amount": 0.00008,
             "side": "Buy"

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -860,13 +860,16 @@ fn account_event_snapshot(assets: &AssetStates) -> EngineEvent<DataKind> {
 }
 
 fn market_event_trade(time_plus: u64, instrument: usize, price: f64) -> EngineEvent<DataKind> {
+    let time_executed = time_plus_days(STARTING_TIMESTAMP, time_plus);
+
     EngineEvent::Market(MarketStreamEvent::Item(MarketEvent {
-        time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
+        time_exchange: time_executed,
         time_received: time_plus_days(STARTING_TIMESTAMP, time_plus),
         exchange: ExchangeId::BinanceSpot,
         instrument: InstrumentIndex(instrument),
         kind: DataKind::Trade(PublicTrade {
             id: time_plus.to_string(),
+            time_executed,
             price,
             amount: 1.0,
             side: Side::Buy,


### PR DESCRIPTION
Add `executed_at` to `PublicTrade`. It's nicer to use if you have the time inside the trade.