### PR TITLE
Spike: Adding dynamic state changes to the audit stream

### DIFF
--- a/barter/examples/example_with_state_updates.rs
+++ b/barter/examples/example_with_state_updates.rs
@@ -1,0 +1,384 @@
+use barter::{
+    EngineEvent,
+    engine::{
+        Engine,
+        audit::EngineAudit,
+        clock::{EngineClock, HistoricalClock},
+        command::Command,
+        run,
+        state::{
+            EngineState,
+            instrument::{filter::InstrumentFilter},
+            trading::TradingState,
+        },
+    },
+    execution::builder::ExecutionBuilder,
+    logging::init_logging,
+    risk::{DefaultRiskManager, DefaultRiskManagerState},
+    statistic::time::Daily,
+    strategy::{DefaultStrategy, DefaultStrategyState},
+};
+use barter_data::{
+    event::DataKind,
+    streams::{
+        consumer::{MarketStreamEvent, MarketStreamResult},
+        reconnect::{Event, stream::ReconnectingStream},
+    },
+};
+use barter_execution::{balance::Balance, client::mock::MockExecutionConfig};
+use barter_instrument::{
+    Underlying,
+    exchange::ExchangeId,
+    index::IndexedInstruments,
+    instrument::{
+        Instrument, InstrumentIndex,
+        spec::{
+            InstrumentSpec, InstrumentSpecNotional, InstrumentSpecPrice, InstrumentSpecQuantity,
+            OrderQuantityUnits,
+        },
+    },
+};
+use barter_integration::{channel::{mpsc_unbounded, ChannelTxDroppable, Tx}, collection::one_or_many::OneOrMany};
+use derive_more::Constructor;
+use fnv::FnvHashMap;
+use futures::{Stream, StreamExt, stream};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use tracing::{debug, info, warn};
+
+const EXCHANGE: ExchangeId = ExchangeId::BinanceSpot;
+const RISK_FREE_RETURN: Decimal = dec!(0.05);
+const MOCK_EXCHANGE_ROUND_TRIP_LATENCY_MS: u64 = 100;
+const MOCK_EXCHANGE_FEES_PERCENT: Decimal = dec!(0.05);
+const STARTING_BALANCE_USDT: Balance = Balance {
+    total: dec!(10_000.0),
+    free: dec!(10_000.0),
+};
+const STARTING_BALANCE_BTC: Balance = Balance {
+    total: dec!(0.1),
+    free: dec!(0.1),
+};
+const STARTING_BALANCE_ETH: Balance = Balance {
+    total: dec!(1.0),
+    free: dec!(1.0),
+};
+const STARTING_BALANCE_SOL: Balance = Balance {
+    total: dec!(10.0),
+    free: dec!(10.0),
+};
+
+const FILE_PATH_HISTORIC_TRADES_AND_L1S: &str =
+    "barter/examples/data/binance_spot_market_data_with_disconnect_events.json";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialise Tracing
+    init_logging();
+
+    // Initialise Channels
+    let (feed_tx, mut feed_rx) = mpsc_unbounded();
+    let (audit_tx, audit_rx) = mpsc_unbounded();
+
+    // Construct IndexedInstruments
+    let instruments = indexed_instruments();
+
+    // Initialise HistoricalClock & MarketStream
+    let (clock, market_stream) =
+        init_historic_clock_and_market_data_stream(FILE_PATH_HISTORIC_TRADES_AND_L1S);
+
+    // Forward market data events to Engine feed
+    tokio::spawn(market_stream.forward_to(feed_tx.clone()));
+
+    // Construct EngineState from IndexedInstruments and hard-coded exchange asset Balances
+    let state = EngineState::<
+        InstrumentMarketData,
+        DefaultStrategyState,
+        DefaultRiskManagerState,
+    >::builder(&instruments)
+    .time_engine_start(clock.time())
+    // Note: you may want to start to engine with TradingState::Disabled and turn on later
+    .trading_state(TradingState::Enabled)
+    .balances([
+        (EXCHANGE, "usdt", STARTING_BALANCE_USDT),
+        (EXCHANGE, "btc", STARTING_BALANCE_BTC),
+        (EXCHANGE, "eth", STARTING_BALANCE_ETH),
+        (EXCHANGE, "sol", STARTING_BALANCE_SOL),
+    ])
+    // Note: can add other initial data via this builder (eg/ exchange asset balances)
+    .build();
+
+    // Generate initial AccountSnapshot from EngineState for BinanceSpot MockExchange
+    // Note: for live-trading this would be automatically fetched via the AccountStream init
+    let mut initial_account = FnvHashMap::from(&state);
+    assert_eq!(initial_account.len(), 1);
+
+    // Initialise ExecutionManager & forward Account Streams to Engine feed
+    let (execution_txs, account_stream) = ExecutionBuilder::new(&instruments)
+        .add_mock(MockExecutionConfig::new(
+            EXCHANGE,
+            initial_account.remove(&EXCHANGE).unwrap(),
+            MOCK_EXCHANGE_ROUND_TRIP_LATENCY_MS,
+            MOCK_EXCHANGE_FEES_PERCENT,
+        ))?
+        .init()
+        .await?;
+    tokio::spawn(account_stream.forward_to(feed_tx.clone()));
+
+    // Construct Engine
+    let mut engine = Engine::new(
+        clock,
+        state,
+        execution_txs,
+        DefaultStrategy::default(),
+        DefaultRiskManager::default(),
+    );
+
+    // Run synchronous Engine on blocking task
+    let engine_task = tokio::task::spawn_blocking(move || {
+        let shutdown_audit = run(
+            &mut feed_rx,
+            &mut engine,
+            &mut ChannelTxDroppable::new(audit_tx),
+        );
+        (engine, shutdown_audit)
+    });
+
+    // Run dummy asynchronous AuditStream consumer
+    // Note: you probably want to use this Stream to replicate EngineState, or persist events, etc.
+    //  --> eg/ see examples/engine_with_replica_engine_state.rs
+    let audit_task = tokio::spawn(async move {
+        let mut audit_stream = audit_rx.into_stream();
+        while let Some(audit) = audit_stream.next().await {
+            debug!(?audit, "AuditStream consumed AuditTick");
+            match &audit.event {
+                EngineAudit::Process(process_audit) => {
+                    // Handle instrument events here
+                    match process_audit {
+                        barter::engine::audit::ProcessAudit::Process(_) => {}
+                        barter::engine::audit::ProcessAudit::ProcessWithOutput(_, one_or_many) => {
+                            match one_or_many {
+                                OneOrMany::One(engine_output) => {
+                                    println!("Engine output: {:?}", engine_output);
+                                }
+                                OneOrMany::Many(items) => {
+                                    println!("Engine outputs: {:?}", items);
+                                }
+                            }
+                        }
+                    }
+                }
+                EngineAudit::Shutdown(_) => break,
+                _ => {}
+            }
+        }
+        audit_stream
+    });
+
+    // Let the example run for 4 seconds..., then:
+    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    // 1. Disable Strategy order generation (still continues to update EngineState)
+    feed_tx.send(TradingState::Disabled)?;
+    // 2. Cancel all open orders
+    feed_tx.send(Command::CancelOrders(InstrumentFilter::None))?;
+    // 3. Send orders to close current positions
+    feed_tx.send(Command::ClosePositions(InstrumentFilter::None))?;
+    // 4. Stop Engine run loop
+    feed_tx.send(EngineEvent::Shutdown)?;
+
+    // Await Engine & AuditStream task graceful shutdown
+    // Note: Engine & AuditStream returned, ready for further use
+    let (engine, _shutdown_audit) = engine_task.await?;
+    let _audit_stream = audit_task.await?;
+
+    // Generate TradingSummary<Daily>
+    let trading_summary = engine
+        .trading_summary_generator(RISK_FREE_RETURN)
+        .generate(Daily);
+
+    // Print TradingSummary<Daily> to terminal (could save in a file, send somewhere, etc.)
+    trading_summary.print_summary();
+
+    Ok(())
+}
+
+fn indexed_instruments() -> IndexedInstruments {
+    IndexedInstruments::builder()
+        .add_instrument(Instrument::spot(
+            EXCHANGE,
+            "binance_spot_btc_usdt",
+            "BTCUSDT",
+            Underlying::new("btc", "usdt"),
+            Some(InstrumentSpec::new(
+                InstrumentSpecPrice::new(dec!(0.01), dec!(0.01)),
+                InstrumentSpecQuantity::new(
+                    OrderQuantityUnits::Quote,
+                    dec!(0.00001),
+                    dec!(0.00001),
+                ),
+                InstrumentSpecNotional::new(dec!(5.0)),
+            )),
+        ))
+        .add_instrument(Instrument::spot(
+            EXCHANGE,
+            "binance_spot_eth_usdt",
+            "ETHUSDT",
+            Underlying::new("eth", "usdt"),
+            Some(InstrumentSpec::new(
+                InstrumentSpecPrice::new(dec!(0.01), dec!(0.01)),
+                InstrumentSpecQuantity::new(OrderQuantityUnits::Quote, dec!(0.0001), dec!(0.0001)),
+                InstrumentSpecNotional::new(dec!(5.0)),
+            )),
+        ))
+        .add_instrument(Instrument::spot(
+            EXCHANGE,
+            "binance_spot_sol_usdt",
+            "SOLUSDT",
+            Underlying::new("sol", "usdt"),
+            Some(InstrumentSpec::new(
+                InstrumentSpecPrice::new(dec!(0.01), dec!(0.01)),
+                InstrumentSpecQuantity::new(OrderQuantityUnits::Quote, dec!(0.001), dec!(0.001)),
+                InstrumentSpecNotional::new(dec!(5.0)),
+            )),
+        ))
+        .build()
+}
+
+// Note that there are far more intelligent ways of streaming historical market data, this is
+// just for demonstration purposes.
+//
+// For example:
+// - Stream from database
+// - Stream from file
+fn init_historic_clock_and_market_data_stream(
+    file_path: &str,
+) -> (
+    HistoricalClock,
+    impl Stream<Item = MarketStreamEvent<InstrumentIndex, DataKind>> + use<>,
+) {
+    let data = std::fs::read_to_string(file_path).unwrap();
+    let events =
+        serde_json::from_str::<Vec<MarketStreamResult<InstrumentIndex, DataKind>>>(&data).unwrap();
+
+    let time_exchange_first = events
+        .iter()
+        .find_map(|result| match result {
+            MarketStreamResult::Item(Ok(event)) => Some(event.time_exchange),
+            _ => None,
+        })
+        .unwrap();
+
+    let clock = HistoricalClock::new(time_exchange_first);
+
+    let stream = stream::iter(events)
+        .with_error_handler(|error| warn!(?error, "MarketStream generated error"))
+        .inspect(|event| match event {
+            Event::Reconnecting(exchange) => {
+                info!(%exchange, "sending historical disconnection to Engine")
+            }
+            Event::Item(event) => {
+                info!(
+                    exchange = %event.exchange,
+                    instrument = %event.instrument,
+                    kind = event.kind.kind_name(),
+                    "sending historical event to Engine"
+                )
+            }
+        });
+
+    (clock, stream)
+}
+
+
+/// Provide a custom instrument data state
+/// 
+/// 
+
+use barter::{
+    engine::{state::instrument::data::InstrumentDataState, Processor, WithAudit},
+    Timed,
+};
+use barter_data::{
+    event::{ MarketEvent},
+    subscription::book::OrderBookL1,
+};
+use chrono::{DateTime, Utc};
+use rust_decimal::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
+)]
+pub struct InstrumentMarketData {
+    pub l1: OrderBookL1,
+    pub last_traded_price: Option<Timed<Decimal>>,
+    //some stateful value... could be a technical indicator on the instrument.
+    pub random_stateful_number: i32,
+}
+
+
+#[derive(Debug, Clone)]
+pub struct InstrumentAuditTick {
+    //this is an optional field and only present when the value has changed from processing the latest event.
+    pub random_stateful_number: Option<i32>,
+}
+
+// Implement WithAudit for DefaultInstrumentMarketData
+impl WithAudit for InstrumentMarketData {
+    type Audit = Option<InstrumentAuditTick>;
+}
+
+impl InstrumentDataState for InstrumentMarketData {
+    type MarketEventKind = DataKind;
+
+    fn price(&self) -> Option<Decimal> {
+        self.l1
+            .volume_weighed_mid_price()
+            .or(self.last_traded_price.as_ref().map(|timed| timed.value))
+    }
+}
+
+impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
+    for InstrumentMarketData
+{
+    fn process(&mut self, event: &MarketEvent<InstrumentKey, DataKind>) -> Self::Audit {
+        match &event.kind {
+            DataKind::Trade(trade) => {
+                if self
+                    .last_traded_price
+                    .as_ref()
+                    .is_none_or(|price| price.time < event.time_exchange)
+                {
+                    if let Some(price) = Decimal::from_f64(trade.price) {
+                        self.last_traded_price
+                            .replace(Timed::new(price, event.time_exchange));
+                    }
+                }
+            }
+            DataKind::OrderBookL1(l1) => {
+                if self.l1.last_update_time < event.time_exchange {
+                    self.l1 = l1.clone()
+                }
+            }
+            _ => {}
+        }
+
+        //we process the market event and perhaps our indicator has changed.
+        self.random_stateful_number = self.random_stateful_number + 1;
+
+        return Some(InstrumentAuditTick {
+            random_stateful_number: Some(self.random_stateful_number),
+        });
+    }
+}
+
+pub trait OurIndicatorTrait {
+    fn random_stateful_number_current(&self) -> i32;
+}
+
+
+impl OurIndicatorTrait for InstrumentMarketData {
+    fn random_stateful_number_current(&self) -> i32 {
+        self.random_stateful_number
+    }
+
+}

--- a/barter/src/engine/state/instrument/data.rs
+++ b/barter/src/engine/state/instrument/data.rs
@@ -1,4 +1,4 @@
-use crate::{Timed, engine::Processor};
+use crate::{Timed, engine::{Processor, WithAudit}};
 use barter_data::{
     event::{DataKind, MarketEvent},
     subscription::book::OrderBookL1,
@@ -54,6 +54,11 @@ pub struct DefaultInstrumentMarketData {
     pub last_traded_price: Option<Timed<Decimal>>,
 }
 
+// Implement WithAudit for DefaultInstrumentMarketData
+impl WithAudit for DefaultInstrumentMarketData {
+    type Audit = ();
+}
+
 impl InstrumentDataState for DefaultInstrumentMarketData {
     type MarketEventKind = DataKind;
 
@@ -67,8 +72,6 @@ impl InstrumentDataState for DefaultInstrumentMarketData {
 impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
     for DefaultInstrumentMarketData
 {
-    type Audit = ();
-
     fn process(&mut self, event: &MarketEvent<InstrumentKey, DataKind>) -> Self::Audit {
         match &event.kind {
             DataKind::Trade(trade) => {

--- a/barter/src/risk/mod.rs
+++ b/barter/src/risk/mod.rs
@@ -1,4 +1,4 @@
-use crate::engine::Processor;
+use crate::engine::{Processor, WithAudit};
 use barter_data::event::MarketEvent;
 use barter_execution::{
     AccountEvent,
@@ -147,14 +147,17 @@ impl<State, ExchangeKey, InstrumentKey> RiskManager<ExchangeKey, InstrumentKey>
 )]
 pub struct DefaultRiskManagerState;
 
+// Implement WithAudit for DefaultRiskManagerState
+impl WithAudit for DefaultRiskManagerState {
+    type Audit = ();
+}
+
 impl<ExchangeKey, AssetKey, InstrumentKey>
     Processor<&AccountEvent<ExchangeKey, AssetKey, InstrumentKey>> for DefaultRiskManagerState
 {
-    type Audit = ();
     fn process(&mut self, _: &AccountEvent<ExchangeKey, AssetKey, InstrumentKey>) -> Self::Audit {}
 }
 
 impl<InstrumentKey, Kind> Processor<&MarketEvent<InstrumentKey, Kind>> for DefaultRiskManagerState {
-    type Audit = ();
     fn process(&mut self, _: &MarketEvent<InstrumentKey, Kind>) -> Self::Audit {}
 }

--- a/barter/src/strategy/mod.rs
+++ b/barter/src/strategy/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     engine::{
-        Engine, Processor,
+        Engine, Processor, WithAudit,
         state::{
             EngineState,
             instrument::{data::InstrumentDataState, filter::InstrumentFilter},
@@ -138,14 +138,21 @@ impl<Clock, State, ExecutionTxs, Risk> OnTradingDisabled<Clock, State, Execution
 )]
 pub struct DefaultStrategyState;
 
+// Implement WithAudit for DefaultStrategyState
+impl WithAudit for DefaultStrategyState {
+    type Audit = Vec<()>;
+}
+
 impl<ExchangeKey, AssetKey, InstrumentKey>
     Processor<&AccountEvent<ExchangeKey, AssetKey, InstrumentKey>> for DefaultStrategyState
 {
-    type Audit = ();
-    fn process(&mut self, _: &AccountEvent<ExchangeKey, AssetKey, InstrumentKey>) -> Self::Audit {}
+    fn process(&mut self, _: &AccountEvent<ExchangeKey, AssetKey, InstrumentKey>) -> Self::Audit {
+        vec![]
+    }
 }
 
 impl<InstrumentKey, Kind> Processor<&MarketEvent<InstrumentKey, Kind>> for DefaultStrategyState {
-    type Audit = ();
-    fn process(&mut self, _: &MarketEvent<InstrumentKey, Kind>) -> Self::Audit {}
+    fn process(&mut self, _: &MarketEvent<InstrumentKey, Kind>) -> Self::Audit {
+        vec![]
+    }
 }


### PR DESCRIPTION
This branch looks to add support for audit events generated from Instrument, Risk, Strategy state updates that are triggered by their processor trait implementations. There are a few changes to make this possible:

1. Refactor the Processor::Audit type. Currently the Audit type is unique per Processor implementation and a given state (i.e. strategy state) implements multiple processors for different event types (e.g. account, market event). These states should potentially always return the same audit type irrespective of the inbound event so the audit type should be tied to the state struct and not the Processor trait. To do this, I've introduced the WithAudit trait which the struct implements and the Processor trait derives it's Audit return type by ensuring that Self implements the WithAudit trait.
2. Make some changes to the engine processor to receive the state change events, put them into a vec and then publish them to the audit stream.

This means that now when you implement a custom InstrumentMarketData type, you need to implement both Processor + WithAudit and you can set this to be () if you don't want to return Audit types or a custom struct.

I've added an example:

```
cargo run --example example_with_state_updates
```

**Currently this only implements the change for instrument data to validate the pattern before adding the changes to strategy + risk**

this should print out the state changes through the audit channel. 

If your run the above example with **DefaultInstrumentMarketData** instead of the currently set custom **InstrumentMarketData** implementation you will get:

```sh

2025-03-20T12:46:05.354157Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354229Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354239Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354247Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354255Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354263Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:46:05.354269Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354277Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354284Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354335Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354347Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354355Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:46:05.354361Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354369Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354376Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354398Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354406Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:46:05.354412Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354420Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:46:05.354427Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354434Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354441Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354450Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354457Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:46:05.354550Z  INFO barter::execution::manager: AccountStream with auto reconnect initialising exchange_index=ExchangeIndex(0) exchange_id=BinanceSpot policy=ReconnectionBackoffPolicy { backoff_ms_initial: 125, backoff_multiplier: 2, backoff_ms_max: 60000 } stream_key=account_stream_mock-BinanceSpot
2025-03-20T12:46:05.457221Z  INFO barter_data::streams::reconnect::stream: successfully initialised Stream attempt=0 stream_key=account_stream_mock-BinanceSpot
2025-03-20T12:46:05.457548Z  INFO barter::engine: Engine running
2025-03-20T12:46:05.457666Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
2025-03-20T12:46:05.457794Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
2025-03-20T12:46:05.457820Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
2025-03-20T12:46:05.458110Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
2025-03-20T12:46:05.458156Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
2025-03-20T12:46:05.458196Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
2025-03-20T12:46:05.458221Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
2025-03-20T12:46:05.458286Z  INFO barter::engine::state::connectivity: EngineState received AccountStream event - setting connection to Healthy exchange=ExchangeIndex(0)
2025-03-20T12:46:05.458312Z  INFO barter::engine::state::connectivity: EngineState setting global connectivity to Healthy
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(())))
2025-03-20T12:46:09.458014Z  INFO barter::engine::state::trading: EngineState setting TradingState::Disabled
2025-03-20T12:46:09.458061Z  INFO barter::engine: Engine actioning user Command::CancelOrders filter=None
Engine output: OnTradingDisabled(())
Engine output: Commanded(CancelOrders(SendRequestsOutput { sent: None, errors: None }))
2025-03-20T12:46:09.458096Z  INFO barter::engine: Engine actioning user Command::ClosePositions filter=None
2025-03-20T12:46:09.458120Z  INFO barter::engine: Engine shutting down shutdown_audit=Commanded(Shutdown)
Engine output: Commanded(ClosePositions(SendCancelsAndOpensOutput { cancels: SendRequestsOutput { sent: None, errors: None }, opens: SendRequestsOutput { sent: None, errors: None } }))

```

Compared to:


2025-03-20T12:47:00.548760Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.548904Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.548926Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.548942Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.548957Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.548974Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:47:00.548985Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549000Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549015Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549079Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549103Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549119Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:47:00.549131Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549146Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549160Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549175Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549189Z  INFO example_with_state_updates: sending historical disconnection to Engine exchange=BinanceSpot
2025-03-20T12:47:00.549200Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549214Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(2) kind="public_trade"
2025-03-20T12:47:00.549228Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.549243Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.549261Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.549276Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.549290Z  INFO example_with_state_updates: sending historical event to Engine exchange=BinanceSpot instrument=InstrumentIndex(0) kind="public_trade"
2025-03-20T12:47:00.549345Z  INFO barter::execution::manager: AccountStream with auto reconnect initialising exchange_index=ExchangeIndex(0) exchange_id=BinanceSpot policy=ReconnectionBackoffPolicy { backoff_ms_initial: 125, backoff_multiplier: 2, backoff_ms_max: 60000 } stream_key=account_stream_mock-BinanceSpot
2025-03-20T12:47:00.652134Z  INFO barter_data::streams::reconnect::stream: successfully initialised Stream attempt=0 stream_key=account_stream_mock-BinanceSpot
2025-03-20T12:47:00.652232Z  INFO barter::engine: Engine running
2025-03-20T12:47:00.652359Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(1) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(2) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(3) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(4) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(1) }))))
2025-03-20T12:47:00.652455Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
2025-03-20T12:47:00.652476Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(2) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(3) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(4) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(5) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(6) }))))
2025-03-20T12:47:00.652519Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
2025-03-20T12:47:00.652547Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(7) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(8) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(9) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(10) }))))
2025-03-20T12:47:00.652576Z  WARN barter::engine::state::connectivity: EngineState received MarketStream disconnect event exchange=BinanceSpot
2025-03-20T12:47:00.652594Z  INFO barter::engine::state::connectivity: EngineState received MarketStream event - setting connection to Healthy exchange=BinanceSpot
Engine output: MarketDisconnect(())
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(11) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(12) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(5) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(6) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(7) }))))
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(8) }))))
2025-03-20T12:47:00.652636Z  INFO barter::engine::state::connectivity: EngineState received AccountStream event - setting connection to Healthy exchange=ExchangeIndex(0)
Engine output: OnStateUpdate(One(OnInstrumentStateUpdate(Some(InstrumentAuditTick { random_stateful_number: Some(9) }))))
2025-03-20T12:47:00.652665Z  INFO barter::engine::state::connectivity: EngineState setting global connectivity to Healthy
2025-03-20T12:47:04.653589Z  INFO barter::engine::state::trading: EngineState setting TradingState::Disabled
2025-03-20T12:47:04.653626Z  INFO barter::engine: Engine actioning user Command::CancelOrders filter=None
Engine output: OnTradingDisabled(())
Engine output: Commanded(CancelOrders(SendRequestsOutput { sent: None, errors: None }))
2025-03-20T12:47:04.653673Z  INFO barter::engine: Engine actioning user Command::ClosePositions filter=None
2025-03-20T12:47:04.653689Z  INFO barter::engine: Engine shutting down shutdown_audit=Commanded(Shutdown)
Engine output: Commanded(ClosePositions(SendCancelsAndOpensOutput { cancels: SendRequestsOutput { sent: None, errors: None }, opens: SendRequestsOutput { sent: None, errors: None } }))
```