### PR TITLE
fix: update market data state from AccountEvent

### DIFF
--- a/barter/src/engine/mod.rs
+++ b/barter/src/engine/mod.rs
@@ -299,6 +299,7 @@ impl<Clock, InstrumentData, StrategyState, RiskState, ExecutionTxs, Strategy, Ri
         event: &AccountStreamEvent,
     ) -> UpdateFromAccountOutput<Strategy::OnDisconnect>
     where
+        InstrumentData: for<'a> Processor<&'a AccountEvent>,
         StrategyState: for<'a> Processor<&'a AccountEvent>,
         RiskState: for<'a> Processor<&'a AccountEvent>,
         Strategy: OnDisconnectStrategy<


### PR DESCRIPTION
Adding missing logic to update `InstrumentData` on the received `AccountEvent`.