### PR TITLE
feat: OrderBook accept OrderBookEvent reference on update

### DIFF
--- a/barter-data/src/books/manager.rs
+++ b/barter-data/src/books/manager.rs
@@ -60,7 +60,7 @@ where
             };
 
             let mut book_lock = book.write();
-            book_lock.update(event.kind);
+            book_lock.update(&event.kind);
         }
     }
 }

--- a/barter-data/src/exchange/binance/futures/l2.rs
+++ b/barter-data/src/exchange/binance/futures/l2.rs
@@ -114,7 +114,7 @@ where
 
                 let sequencer = BinanceFuturesUsdOrderBookL2Sequencer {
                     updates_processed: 0,
-                    last_update_id: snapshot.sequence,
+                    last_update_id: snapshot.sequence(),
                 };
 
                 Ok((
@@ -730,7 +730,7 @@ mod tests {
                     valid_update.asks,
                 ));
 
-                test.book.update(barter_update);
+                test.book.update(&barter_update);
             }
 
             assert_eq!(test.book, test.expected, "TC{index} failed");

--- a/barter-data/src/exchange/binance/spot/l2.rs
+++ b/barter-data/src/exchange/binance/spot/l2.rs
@@ -109,7 +109,7 @@ where
 
                 let book_meta = BinanceOrderBookL2Meta::new(
                     instrument_key,
-                    BinanceSpotOrderBookL2Sequencer::new(snapshot.sequence),
+                    BinanceSpotOrderBookL2Sequencer::new(snapshot.sequence()),
                 );
 
                 Ok((sub_id, book_meta))
@@ -699,7 +699,7 @@ mod tests {
                     valid_update.asks,
                 ));
 
-                test.book.update(barter_update);
+                test.book.update(&barter_update);
             }
 
             assert_eq!(test.book, test.expected, "TC{index} failed");


### PR DESCRIPTION
Enable usage of the `OrderBook` in the `InstrumentMarketData`, without needing to clone event on the update. The PR contains some additional smaller improvements.

Example:
```rust 
#[derive(Debug, Clone)]
pub struct InstrumentMarketData {
    pub orderbook: OrderBook,
}

impl Processor<&MarketEvent<InstrumentIndex>> for InstrumentMarketData {
    type Audit = ();

    fn process(&mut self, event: &MarketEvent<InstrumentIndex>) -> Self::Audit {
        match &event.kind {
            DataKind::OrderBook(event) => {
               self.orderbook.update(event);
            }
            event => {
                warn!(
                    ?event,
                    "InstrumentMarketData unhandled market event"
                );
            }
        }
    }
}```