### PR TITLE
feat: pass name_internal in InstrumentData initialization

### DIFF
--- a/barter/benches/backtest/mod.rs
+++ b/barter/benches/backtest/mod.rs
@@ -464,11 +464,9 @@ fn args_constant(
     let time_engine_start = DateTime::<Utc>::from_str("2025-03-25T23:07:00.773674205Z").unwrap();
 
     // Construct EngineState
-    let engine_state = EngineStateBuilder::new(
-        &instruments,
-        DefaultGlobalData::default(),
-        LoseMoneyInstrumentData::default,
-    )
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData::default(), |_| {
+        LoseMoneyInstrumentData::default()
+    })
     .time_engine_start(time_engine_start)
     .trading_state(TradingState::Enabled)
     .build();

--- a/barter/examples/backtests_concurrent.rs
+++ b/barter/examples/backtests_concurrent.rs
@@ -57,11 +57,9 @@ async fn main() {
     let time_engine_start = market_data.time_first_event().await.unwrap();
 
     // Construct EngineState
-    let engine_state = EngineStateBuilder::new(
-        &instruments,
-        DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
-    )
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData::default(), |_| {
+        DefaultInstrumentMarketData::default()
+    })
     .time_engine_start(time_engine_start)
     .trading_state(TradingState::Enabled)
     .build();

--- a/barter/examples/engine_async_with_historic_market_data_and_mock_execution.rs
+++ b/barter/examples/engine_async_with_historic_market_data_and_mock_execution.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultRiskManager::default(),
         market_stream,
         DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
+        |_| DefaultInstrumentMarketData::default(),
     );
 
     // Build & run full system:

--- a/barter/examples/engine_sync_with_audit_replica_engine_state.rs
+++ b/barter/examples/engine_sync_with_audit_replica_engine_state.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultRiskManager::default(),
         market_stream,
         DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
+        |_| DefaultInstrumentMarketData::default(),
     );
 
     // Construct SystemBuild:

--- a/barter/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
+++ b/barter/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultRiskManager::default(),
         market_stream,
         DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
+        |_| DefaultInstrumentMarketData::default(),
     );
 
     // Build & run full system:

--- a/barter/examples/engine_sync_with_multiple_strategies.rs
+++ b/barter/examples/engine_sync_with_multiple_strategies.rs
@@ -339,7 +339,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultRiskManager::default(),
         market_stream,
         DefaultGlobalData::default(),
-        || MultiStrategyCustomInstrumentData::init(Utc::now()),
+        |_| MultiStrategyCustomInstrumentData::init(Utc::now()),
     );
 
     // Build & run System:

--- a/barter/examples/engine_sync_with_risk_manager_open_order_checks.rs
+++ b/barter/examples/engine_sync_with_risk_manager_open_order_checks.rs
@@ -220,7 +220,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DefaultRiskManager::default(),
         market_stream,
         DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
+        |_| DefaultInstrumentMarketData::default(),
     );
 
     // Build & run full system:

--- a/barter/examples/statistical_trading_summary.rs
+++ b/barter/examples/statistical_trading_summary.rs
@@ -51,11 +51,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time_now = Utc::now();
 
     // Construct EngineState from IndexedInstruments and hard-coded exchange asset Balances
-    let state = EngineState::builder(
-        &instruments,
-        DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
-    )
+    let state = EngineState::builder(&instruments, DefaultGlobalData::default(), |_| {
+        DefaultInstrumentMarketData::default()
+    })
     .time_engine_start(time_now)
     // Note: you may want to start to engine with TradingState::Disabled and turn on later
     .trading_state(TradingState::Enabled)

--- a/barter/src/engine/state/builder.rs
+++ b/barter/src/engine/state/builder.rs
@@ -9,6 +9,7 @@ use barter_instrument::{
     Keyed,
     asset::{ExchangeAsset, name::AssetNameInternal},
     index::IndexedInstruments,
+    instrument::name::InstrumentNameInternal,
 };
 use barter_integration::snapshot::Snapshot;
 use chrono::{DateTime, Utc};
@@ -97,7 +98,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
     /// If optional data is not provided (eg/ Balances), default values are used (eg/ zero Balance).
     pub fn build<InstrumentData>(self) -> EngineState<GlobalData, InstrumentData>
     where
-        FnInstrumentData: FnMut() -> InstrumentData,
+        FnInstrumentData: FnMut(InstrumentNameInternal) -> InstrumentData,
     {
         let Self {
             instruments,

--- a/barter/src/engine/state/instrument/mod.rs
+++ b/barter/src/engine/state/instrument/mod.rs
@@ -253,6 +253,7 @@ pub struct InstrumentState<
     pub key: InstrumentKey,
 
     /// Complete instrument definition.
+    /// TODO: Rename to `info`
     pub instrument: Instrument<ExchangeKey, AssetKey>,
 
     /// TearSheet generator for summarising the trading performance associated with an Instrument.
@@ -426,7 +427,7 @@ pub fn generate_indexed_instrument_states<FnPosMan, FnOrders, FnInsData, Instrum
 where
     FnPosMan: Fn() -> PositionManager,
     FnOrders: Fn() -> Orders,
-    FnInsData: FnMut() -> InstrumentData,
+    FnInsData: FnMut(InstrumentNameInternal) -> InstrumentData,
 {
     InstrumentStates(
         instruments
@@ -443,7 +444,8 @@ where
                         TearSheetGenerator::init(time_engine_start),
                         position_manager_init(),
                         orders_init(),
-                        instrument_data_init(),
+                        // TODO: Check if clone is needed here.
+                        instrument_data_init(instrument.value.name_internal.clone()),
                     ),
                 )
             })

--- a/barter/src/engine/state/mod.rs
+++ b/barter/src/engine/state/mod.rs
@@ -20,7 +20,7 @@ use barter_instrument::{
     asset::{AssetIndex, QuoteAsset},
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
-    instrument::InstrumentIndex,
+    instrument::{InstrumentIndex, name::InstrumentNameInternal},
 };
 use barter_integration::{collection::one_or_many::OneOrMany, snapshot::Snapshot};
 use derive_more::Constructor;
@@ -84,7 +84,7 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
         instrument_data_init: FnInstrumentData,
     ) -> EngineStateBuilder<'_, GlobalData, FnInstrumentData>
     where
-        FnInstrumentData: FnMut() -> InstrumentData,
+        FnInstrumentData: FnMut(InstrumentNameInternal) -> InstrumentData,
     {
         EngineStateBuilder::new(instruments, global, instrument_data_init)
     }

--- a/barter/src/system/builder.rs
+++ b/barter/src/system/builder.rs
@@ -21,6 +21,7 @@ use barter_instrument::{
     Keyed,
     asset::{ExchangeAsset, name::AssetNameInternal},
     index::IndexedInstruments,
+    instrument::name::InstrumentNameInternal,
 };
 use barter_integration::{
     FeedEnded, Terminal,
@@ -195,7 +196,7 @@ impl<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData>
     >
     where
         Clock: EngineClock + Clone + Send + Sync + 'static,
-        FnInstrumentData: FnMut() -> InstrumentData,
+        FnInstrumentData: FnMut(InstrumentNameInternal) -> InstrumentData,
     {
         let Self {
             args:

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -832,11 +832,9 @@ fn build_engine(
 
     let clock = HistoricalClock::new(STARTING_TIMESTAMP);
 
-    let state = EngineState::builder(
-        &instruments,
-        DefaultGlobalData::default(),
-        DefaultInstrumentMarketData::default,
-    )
+    let state = EngineState::builder(&instruments, DefaultGlobalData::default(), |_| {
+        DefaultInstrumentMarketData::default()
+    })
     .time_engine_start(STARTING_TIMESTAMP)
     .trading_state(trading_state)
     .balances([

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 edition = "2024"
-imports_granularity = "crate"
+imports_granularity = "Crate"


### PR DESCRIPTION
It enables us to initialize custom `InstrumentData` with specific data based on the instrument. 

The example is part of the system that is persisting part of the `InstrumentMarketData` to the filesystem. In the code we can see how the persisted state is used to initialize the `InstrumentMarketData`.
```rust
// Construct System Args
let args = SystemArgs::new(
    &instruments,
    config.system.executions,
    LiveClock,
    strategy,
    risk_manager,
    market_stream,
    GlobalData,
    |name| {
        let persisted = persisted_state
            .as_ref()
            .and_then(|s| s.instruments.get(&name))
            .copied();

        match persisted {
            Some(state) => InstrumentMarketData::from_persisted(state),
            None => InstrumentMarketData::new(
                config.strategy.something,
            ),
        }
    },
);
```