### PR TITLE
feat: ExecutionClient return Option from open_order and cancel_order

### DIFF
--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -47,12 +47,12 @@ where
     fn cancel_order(
         &self,
         request: OrderRequestCancel<ExchangeId, &InstrumentNameExchange>,
-    ) -> impl Future<Output = UnindexedOrderResponseCancel> + Send;
+    ) -> impl Future<Output = Option<UnindexedOrderResponseCancel>> + Send;
 
     fn cancel_orders<'a>(
         &self,
         requests: impl IntoIterator<Item = OrderRequestCancel<ExchangeId, &'a InstrumentNameExchange>>,
-    ) -> impl Stream<Item = UnindexedOrderResponseCancel> {
+    ) -> impl Stream<Item = Option<UnindexedOrderResponseCancel>> {
         futures::stream::FuturesUnordered::from_iter(
             requests
                 .into_iter()
@@ -64,14 +64,17 @@ where
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
     ) -> impl Future<
-        Output = Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        Output = Option<
+            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        >,
     > + Send;
 
     fn open_orders<'a>(
         &self,
         requests: impl IntoIterator<Item = OrderRequestOpen<ExchangeId, &'a InstrumentNameExchange>>,
-    ) -> impl Stream<Item = Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>
-    {
+    ) -> impl Stream<
+        Item = Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>,
+    > {
         futures::stream::FuturesUnordered::from_iter(
             requests.into_iter().map(|request| self.open_order(request)),
         )


### PR DESCRIPTION
This PR is a prerequisite for a bybit execution client. This enables the execution clients to specify if the result from `open` and `cancel` should be used as a confirmation of that action or not.

On many exchanges the HTTP 200 result of a `open_order` or `cancel_order` doesn't indicate that the order will actually be opened or canceled. The 200 only means that the request was successfully received and should be processed by the system. In case of the successfully received cancellation request. The order can still be executed if the cancellation was not processed fast enough.

Bybit:
https://bybit-exchange.github.io/docs/v5/order/create-order -> `The ack of create order request indicates that the request is successfully accepted. Please use websocket order stream to confirm the order status`
https://bybit-exchange.github.io/docs/v5/order/cancel-order -> `The ack of cancel order request indicates that the request is successfully accepted. Please use websocket order stream to confirm the order status`

Binance:
https://developers.binance.com/docs/binance-spot-api-docs/rest-api/trading-endpoints#new-order-trade -> `newOrderRespType` can be used to specify what does the HTTP response mean

Example of usage in the Bybit execution client:
https://github.com/barter-rs/barter-rs/blob/66e6cbc4428582acba02a48bac37d49683978462/barter-execution/src/client/bybit/client.rs#L253
https://github.com/barter-rs/barter-rs/blob/66e6cbc4428582acba02a48bac37d49683978462/barter-execution/src/client/bybit/client.rs#L205