### PR TITLE
Okx baseurl update

### DIFF
--- a/barter-data/src/exchange/okx/mod.rs
+++ b/barter-data/src/exchange/okx/mod.rs
@@ -35,7 +35,7 @@ pub mod trade;
 /// [`Okx`] server base url.
 ///
 /// See docs: <https://www.okx.com/docs-v5/en/#overview-api-resources-and-support>
-pub const BASE_URL_OKX: &str = "wss://wsaws.okx.com:8443/ws/v5/public";
+pub const BASE_URL_OKX: &str = "wss://ws.okx.com:8443/ws/v5/public";
 
 /// [`Okx`] server [`PingInterval`] duration.
 ///


### PR DESCRIPTION
Running cargo run --example dynamic_multi_stream_multi_exchange before the change results in a panic. This comes due to old OKX base url not working anymore. This pr fixes it.