### PR TITLE
Bugfix: Updated depreciated coinbase base url

### DIFF
--- a/barter-data/src/exchange/coinbase/mod.rs
+++ b/barter-data/src/exchange/coinbase/mod.rs
@@ -35,7 +35,7 @@ pub mod trade;
 /// [`Coinbase`] server base url.
 ///
 /// See docs: <https://docs.cloud.coinbase.com/exchange/docs/websocket-overview>
-pub const BASE_URL_COINBASE: &str = "wss://ws-feed.execution.coinbase.com";
+pub const BASE_URL_COINBASE: &str = "wss://ws-feed.exchange.coinbase.com";
 
 /// [`Coinbase`] execution.
 ///


### PR DESCRIPTION
Updated depreciated coinbase base url. See: https://docs.cdp.coinbase.com/exchange/docs/websocket-overview.

This fixes #180 