### PR TITLE
fix: lookup in ExecutionInstrumentsMap with multiple exchanges

### DIFF
--- a/barter-execution/src/map.rs
+++ b/barter-execution/src/map.rs
@@ -1,12 +1,12 @@
 use crate::error::KeyError;
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, name::AssetNameExchange},
+    asset::{Asset, AssetIndex, ExchangeAsset, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     index::{IndexedInstruments, error::IndexError},
-    instrument::{InstrumentIndex, name::InstrumentNameExchange},
+    instrument::{Instrument, InstrumentIndex, name::InstrumentNameExchange},
 };
-use barter_integration::collection::FnvIndexMap;
+use barter_integration::collection::FnvIndexSet;
 use fnv::FnvHashMap;
 
 /// Indexed instrument map used to associate the internal Barter representation of instruments and
@@ -20,10 +20,19 @@ use fnv::FnvHashMap;
 /// eg/ `AssetNameExchange("XBT")` <--> `AssetIndex(1)`
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExecutionInstrumentMap {
+    /// The exchange associated with this execution map.
     pub exchange: Keyed<ExchangeIndex, ExchangeId>,
-    pub assets: FnvIndexMap<AssetIndex, AssetNameExchange>,
-    pub instruments: FnvIndexMap<InstrumentIndex, InstrumentNameExchange>,
+    /// Collection of assets available by the engine with their
+    /// exchange-specific representations. This holds all indexed assets.
+    pub assets: FnvIndexSet<ExchangeAsset<Asset>>,
+    /// Collection of instruments available by the engine. This holds all
+    /// indexed instruments.
+    pub instruments: FnvIndexSet<Instrument<Keyed<ExchangeIndex, ExchangeId>, AssetIndex>>,
+    /// Map from exchange-specific asset names to internal asset indices for
+    /// fast lookups.
     pub asset_names: FnvHashMap<AssetNameExchange, AssetIndex>,
+    /// Map from exchange-specific instrument names to internal instrument
+    /// indices for fast lookups.
     pub instrument_names: FnvHashMap<InstrumentNameExchange, InstrumentIndex>,
 }
 
@@ -31,30 +40,55 @@ impl ExecutionInstrumentMap {
     /// Construct a new [`Self`] using the provided indexed assets and instruments.
     pub fn new(
         exchange: Keyed<ExchangeIndex, ExchangeId>,
-        assets: FnvIndexMap<AssetIndex, AssetNameExchange>,
-        instruments: FnvIndexMap<InstrumentIndex, InstrumentNameExchange>,
+        instruments: &IndexedInstruments,
     ) -> Self {
+        let asset_names = instruments
+            .assets()
+            .iter()
+            .filter_map(|Keyed { key, value }| {
+                (value.exchange == exchange.value)
+                    .then_some((value.asset.name_exchange.clone(), *key))
+            })
+            .collect();
+
+        let assets = instruments
+            .assets()
+            .iter()
+            .map(|Keyed { value, .. }| value.clone())
+            .collect();
+
+        let instrument_names = instruments
+            .instruments()
+            .iter()
+            .filter_map(|Keyed { key, value }| {
+                (value.exchange.value == exchange.value)
+                    .then_some((value.name_exchange.clone(), *key))
+            })
+            .collect();
+
+        let instruments = instruments
+            .instruments()
+            .iter()
+            .map(|Keyed { value, .. }| value.clone())
+            .collect();
+
         Self {
             exchange,
-            asset_names: assets
-                .iter()
-                .map(|(key, value)| (value.clone(), *key))
-                .collect(),
-            instrument_names: instruments
-                .iter()
-                .map(|(key, value)| (value.clone(), *key))
-                .collect(),
-            assets: assets,
-            instruments: instruments,
+            asset_names,
+            instrument_names,
+            assets,
+            instruments,
         }
     }
 
     pub fn exchange_assets(&self) -> impl Iterator<Item = &AssetNameExchange> {
-        self.assets.values()
+        self.asset_names.iter().map(|(asset, _)| asset)
     }
 
     pub fn exchange_instruments(&self) -> impl Iterator<Item = &InstrumentNameExchange> {
-        self.instruments.values()
+        self.instrument_names
+            .iter()
+            .map(|(instrument, _)| instrument)
     }
 
     pub fn find_exchange_id(&self, exchange: ExchangeIndex) -> Result<ExchangeId, KeyError> {
@@ -81,9 +115,12 @@ impl ExecutionInstrumentMap {
         &self,
         asset: AssetIndex,
     ) -> Result<&AssetNameExchange, KeyError> {
-        self.assets.get(&asset).ok_or_else(|| {
-            KeyError::AssetKey(format!("ExecutionInstrumentMap does not contain: {asset}"))
-        })
+        self.assets
+            .get_index(asset.index())
+            .ok_or_else(|| {
+                KeyError::AssetKey(format!("ExecutionInstrumentMap does not contain: {asset}"))
+            })
+            .map(|asset| &asset.asset.name_exchange)
     }
 
     pub fn find_asset_index(&self, asset: &AssetNameExchange) -> Result<AssetIndex, IndexError> {
@@ -96,11 +133,14 @@ impl ExecutionInstrumentMap {
         &self,
         instrument: InstrumentIndex,
     ) -> Result<&InstrumentNameExchange, KeyError> {
-        self.instruments.get(&instrument).ok_or_else(|| {
-            KeyError::InstrumentKey(format!(
-                "ExecutionInstrumentMap does not contain: {instrument}"
-            ))
-        })
+        self.instruments
+            .get_index(instrument.index())
+            .ok_or_else(|| {
+                KeyError::InstrumentKey(format!(
+                    "ExecutionInstrumentMap does not contain: {instrument}"
+                ))
+            })
+            .map(|instrument| &instrument.name_exchange)
     }
 
     pub fn find_instrument_index(
@@ -134,22 +174,7 @@ pub fn generate_execution_instrument_map(
 
     Ok(ExecutionInstrumentMap::new(
         Keyed::new(exchange_index, exchange),
-        instruments
-            .assets()
-            .iter()
-            .filter_map(|asset| {
-                (asset.value.exchange == exchange)
-                    .then_some((asset.key, asset.value.asset.name_exchange.clone()))
-            })
-            .collect(),
-        instruments
-            .instruments()
-            .iter()
-            .filter_map(|instrument| {
-                (instrument.value.exchange.value == exchange)
-                    .then_some((instrument.key, instrument.value.name_exchange.clone()))
-            })
-            .collect(),
+        instruments,
     ))
 }
 
@@ -169,9 +194,54 @@ mod tests {
     }
 
     #[test]
+    fn test_find_exchange_id() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let exchange_id = kraken.find_exchange_id(kraken.exchange.key).unwrap();
+        assert_eq!(exchange_id, ExchangeId::Kraken);
+    }
+
+    #[test]
+    fn test_find_exchange_index() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let exchange_index = kraken.find_exchange_index(ExchangeId::Kraken).unwrap();
+        assert_eq!(exchange_index, kraken.exchange.key);
+    }
+
+    #[test]
+    fn test_find_exchange_id_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        // Create a different exchange index that doesn't match
+        let binance_index = instruments
+            .exchanges()
+            .iter()
+            .find(|ex| ex.value == ExchangeId::BinanceSpot)
+            .map(|ex| ex.key)
+            .unwrap();
+
+        let result = kraken.find_exchange_id(binance_index);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(KeyError::ExchangeId(_))));
+    }
+
+    #[test]
+    fn test_find_exchange_index_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let result = kraken.find_exchange_index(ExchangeId::BinanceSpot);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(IndexError::ExchangeIndex(_))));
+    }
+
+    #[test]
     fn test_find_asset_name_exchange() {
         let instruments = indexed_instruments();
-
         let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
 
         let usdt = test_utils::asset("USDT");
@@ -184,11 +254,46 @@ mod tests {
     }
 
     #[test]
-    fn test_find_instrument_name_exchange() {
+    fn test_find_asset_index() {
         let instruments = indexed_instruments();
-
         let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
 
+        let usdc = test_utils::asset("USDC");
+        let asset_index = kraken.find_asset_index(&usdc.name_exchange).unwrap();
+
+        let expected_index = instruments
+            .find_asset_index(ExchangeId::Kraken, &usdc.name_internal)
+            .unwrap();
+        assert_eq!(asset_index, expected_index);
+    }
+
+    #[test]
+    fn test_find_asset_index_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let btc = test_utils::asset("BTC");
+        let result = kraken.find_asset_index(&btc.name_exchange);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(IndexError::AssetIndex(_))));
+    }
+
+    #[test]
+    fn test_find_asset_name_exchange_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        // Try to find asset with invalid index
+        let invalid_index = AssetIndex::new(999);
+        let result = kraken.find_asset_name_exchange(invalid_index);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(KeyError::AssetKey(_))));
+    }
+
+    #[test]
+    fn test_find_instrument_name_exchange() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
         let usdc_usdt = test_utils::instrument(ExchangeId::Kraken, "USDC", "USDT");
 
         let usdc_usdt_index = instruments
@@ -200,5 +305,92 @@ mod tests {
             .unwrap();
 
         assert_eq!(usdc_usdt_exchange_name, &usdc_usdt.name_exchange);
+    }
+
+    #[test]
+    fn test_find_instrument_index() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let usdc_usdt = test_utils::instrument(ExchangeId::Kraken, "USDC", "USDT");
+        let instrument_index = kraken
+            .find_instrument_index(&usdc_usdt.name_exchange)
+            .unwrap();
+
+        let expected_index = instruments
+            .find_instrument_index(ExchangeId::Kraken, &usdc_usdt.name_internal)
+            .unwrap();
+        assert_eq!(instrument_index, expected_index);
+    }
+
+    #[test]
+    fn test_find_instrument_index_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let btc_eth = test_utils::instrument(ExchangeId::Kraken, "BTC", "ETH");
+        let result = kraken.find_instrument_index(&btc_eth.name_exchange);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(IndexError::InstrumentIndex(_))));
+    }
+
+    #[test]
+    fn test_find_instrument_name_exchange_error() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        // Try to find instrument with invalid index
+        let invalid_index = InstrumentIndex::new(999);
+        let result = kraken.find_instrument_name_exchange(invalid_index);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(KeyError::InstrumentKey(_))));
+    }
+
+    #[test]
+    fn test_exchange_assets_iterator() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let exchange_assets: Vec<&AssetNameExchange> = kraken.exchange_assets().collect();
+
+        // Verify that the iterator returns the expected assets for Kraken
+        let expected_assets = vec!["USDC", "USDT"];
+        for expected in &expected_assets {
+            assert!(
+                exchange_assets
+                    .iter()
+                    .any(|asset| asset.as_ref() == *expected)
+            );
+        }
+    }
+
+    #[test]
+    fn test_exchange_instruments_iterator() {
+        let instruments = indexed_instruments();
+        let kraken = generate_execution_instrument_map(&instruments, ExchangeId::Kraken).unwrap();
+
+        let exchange_instruments: Vec<&InstrumentNameExchange> =
+            kraken.exchange_instruments().collect();
+
+        // Should have exactly one instrument for Kraken
+        assert_eq!(exchange_instruments.len(), 1);
+
+        // Verify it contains the USDC-USDT instrument
+        let usdc_usdt = test_utils::instrument(ExchangeId::Kraken, "USDC", "USDT");
+        assert!(
+            exchange_instruments
+                .iter()
+                .any(|instr| *instr == &usdc_usdt.name_exchange)
+        );
+    }
+
+    #[test]
+    fn test_generate_execution_instrument_map_error() {
+        let instruments = indexed_instruments();
+
+        // Try to generate map for exchange not in indexed instruments
+        let result = generate_execution_instrument_map(&instruments, ExchangeId::Bitstamp);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(IndexError::ExchangeIndex(_))));
     }
 }


### PR DESCRIPTION
Currently `find_asset_name_exchange` incorrectly assumes that
`self.assets` contains all the assets. This assumption breaks
with multiple exchanges that have different assets. In such
a case `self.assets` is a proper subset of all assets.

A regression test in this change show how to reproduce the error:
```
 AssetKey("ExecutionInstrumentMap does not contain: AssetIndex(5)")
```

A similar issue exists in `find_instrument_name_exchange`.

This change fixes the two bugs by using maps instead of sets.

Issue: #213 