### PR TITLE
feat: add filtering parameters to ExecutionClient fetch methods

### DIFF
--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -238,12 +238,14 @@ where
 
     async fn fetch_balances(
         &self,
+        assets: &[AssetNameExchange],
     ) -> Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         self.request_tx
             .send(MockExchangeRequest::fetch_balances(
                 self.time_request(),
+                assets.to_vec(),
                 response_tx,
             ))
             .map_err(|_| {
@@ -261,12 +263,14 @@ where
 
     async fn fetch_open_orders(
         &self,
+        instruments: &[InstrumentNameExchange],
     ) -> Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         self.request_tx
             .send(MockExchangeRequest::fetch_orders_open(
                 self.time_request(),
+                instruments.to_vec(),
                 response_tx,
             ))
             .map_err(|_| {

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -82,10 +82,12 @@ where
 
     fn fetch_balances(
         &self,
+        assets: &[AssetNameExchange],
     ) -> impl Future<Output = Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError>>;
 
     fn fetch_open_orders(
         &self,
+        instruments: &[InstrumentNameExchange],
     ) -> impl Future<
         Output = Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError>,
     >;

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -78,12 +78,28 @@ impl MockExchange {
                     let snapshot = self.account_snapshot();
                     self.respond_with_latency(response_tx, snapshot);
                 }
-                MockExchangeRequestKind::FetchBalances { response_tx } => {
-                    let balances = self.account.balances().cloned().collect();
+                MockExchangeRequestKind::FetchBalances {
+                    response_tx,
+                    assets,
+                } => {
+                    let balances = self
+                        .account
+                        .balances()
+                        .filter(|balance| assets.contains(&balance.asset))
+                        .cloned()
+                        .collect();
                     self.respond_with_latency(response_tx, balances);
                 }
-                MockExchangeRequestKind::FetchOrdersOpen { response_tx } => {
-                    let orders_open = self.account.orders_open().cloned().collect();
+                MockExchangeRequestKind::FetchOrdersOpen {
+                    response_tx,
+                    instruments,
+                } => {
+                    let orders_open = self
+                        .account
+                        .orders_open()
+                        .filter(|order| instruments.contains(&order.key.instrument))
+                        .cloned()
+                        .collect();
                     self.respond_with_latency(response_tx, orders_open);
                 }
                 MockExchangeRequestKind::FetchTrades {

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -40,21 +40,29 @@ impl MockExchangeRequest {
 
     pub fn fetch_balances(
         time_request: DateTime<Utc>,
+        assets: Vec<AssetNameExchange>,
         response_tx: oneshot::Sender<Vec<AssetBalance<AssetNameExchange>>>,
     ) -> Self {
         Self::new(
             time_request,
-            MockExchangeRequestKind::FetchBalances { response_tx },
+            MockExchangeRequestKind::FetchBalances {
+                response_tx,
+                assets,
+            },
         )
     }
 
     pub fn fetch_orders_open(
         time_request: DateTime<Utc>,
+        instruments: Vec<InstrumentNameExchange>,
         response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
     ) -> Self {
         Self::new(
             time_request,
-            MockExchangeRequestKind::FetchOrdersOpen { response_tx },
+            MockExchangeRequestKind::FetchOrdersOpen {
+                response_tx,
+                instruments,
+            },
         )
     }
 
@@ -109,9 +117,11 @@ pub enum MockExchangeRequestKind {
         response_tx: oneshot::Sender<UnindexedAccountSnapshot>,
     },
     FetchBalances {
+        assets: Vec<AssetNameExchange>,
         response_tx: oneshot::Sender<Vec<AssetBalance<AssetNameExchange>>>,
     },
     FetchOrdersOpen {
+        instruments: Vec<InstrumentNameExchange>,
         response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
     },
     FetchTrades {


### PR DESCRIPTION
Some exchanges require you to specify the assets and instruments when fetching balances and orders. It's also good to have access to the assets/instruments when fetching. For possible optimization if the exchange allows you to specify them on request.

* https://phemex-docs.github.io/#query-account-positions
* https://phemex-docs.github.io/#query-open-orders-by-symbol