### PR TITLE
feat: make AuditSpanFilter public for external reuse

### DIFF
--- a/barter/src/logging.rs
+++ b/barter/src/logging.rs
@@ -33,7 +33,7 @@ pub fn init_json_logging() {
         .init()
 }
 
-struct AuditSpanFilter;
+pub struct AuditSpanFilter;
 
 impl<S> tracing_subscriber::layer::Layer<S> for AuditSpanFilter
 where


### PR DESCRIPTION
Allow users to import and use AuditSpanFilter in custom logging  configurations while still filtering out noisy audit replica logs. 