### PR TITLE
refactor: simplify fee representation by removing generic type

### DIFF
--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -12,9 +12,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
@@ -289,7 +287,7 @@ where
     async fn fetch_trades(
         &self,
         time_since: DateTime<Utc>,
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<InstrumentNameExchange>>, UnindexedClientError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         self.request_tx

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -10,9 +10,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use futures::Stream;
@@ -95,5 +93,5 @@ where
     fn fetch_trades(
         &self,
         time_since: DateTime<Utc>,
-    ) -> impl Future<Output = Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError>>;
+    ) -> impl Future<Output = Result<Vec<Trade<InstrumentNameExchange>>, UnindexedClientError>>;
 }

--- a/barter-execution/src/exchange/mock/account.rs
+++ b/barter-execution/src/exchange/mock/account.rs
@@ -9,9 +9,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
@@ -23,7 +21,7 @@ pub struct AccountState {
     orders_open: FnvHashMap<ClientOrderId, Order<ExchangeId, InstrumentNameExchange, Open>>,
     orders_cancelled:
         FnvHashMap<ClientOrderId, Order<ExchangeId, InstrumentNameExchange, Cancelled>>,
-    trades: Vec<Trade<QuoteAsset, InstrumentNameExchange>>,
+    trades: Vec<Trade<InstrumentNameExchange>>,
 }
 
 impl AccountState {
@@ -56,7 +54,7 @@ impl AccountState {
     pub fn trades(
         &self,
         time_since: DateTime<Utc>,
-    ) -> impl Iterator<Item = &Trade<QuoteAsset, InstrumentNameExchange>> + '_ {
+    ) -> impl Iterator<Item = &Trade<InstrumentNameExchange>> + '_ {
         self.trades
             .iter()
             .filter(move |trade| trade.time_exchange >= time_since)
@@ -69,7 +67,7 @@ impl AccountState {
         self.balances.get_mut(asset)
     }
 
-    pub fn ack_trade(&mut self, trade: Trade<QuoteAsset, InstrumentNameExchange>) {
+    pub fn ack_trade(&mut self, trade: Trade<InstrumentNameExchange>) {
         self.trades.push(trade);
     }
 }

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use barter_instrument::{
     Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
+    asset::name::AssetNameExchange,
     exchange::ExchangeId,
     instrument::{Instrument, name::InstrumentNameExchange},
 };
@@ -306,7 +306,7 @@ impl MockExchange {
                     current.balance.total = maybe_new_balance;
                     current.time_exchange = time_exchange;
 
-                    Ok((current.clone(), AssetFees::quote_fees(order_fees_quote)))
+                    Ok((current.clone(), AssetFees::quote(order_fees_quote)))
                 } else {
                     Err(ApiError::BalanceInsufficient(
                         underlying.quote,
@@ -340,7 +340,7 @@ impl MockExchange {
 
                     let fees_quote = order_fees_base * request.state.price;
 
-                    Ok((current.clone(), AssetFees::quote_fees(fees_quote)))
+                    Ok((current.clone(), AssetFees::quote(fees_quote)))
                 } else {
                     Err(ApiError::BalanceInsufficient(
                         underlying.quote,
@@ -456,5 +456,5 @@ where
 #[derive(Debug)]
 pub struct OpenOrderNotifications {
     pub balance: Snapshot<AssetBalance<AssetNameExchange>>,
-    pub trade: Trade<QuoteAsset, InstrumentNameExchange>,
+    pub trade: Trade<InstrumentNameExchange>,
 }

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -10,9 +10,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use tokio::sync::oneshot;
@@ -68,7 +66,7 @@ impl MockExchangeRequest {
 
     pub fn fetch_trades(
         time_request: DateTime<Utc>,
-        response_tx: oneshot::Sender<Vec<Trade<QuoteAsset, InstrumentNameExchange>>>,
+        response_tx: oneshot::Sender<Vec<Trade<InstrumentNameExchange>>>,
         time_since: DateTime<Utc>,
     ) -> Self {
         Self::new(
@@ -125,7 +123,7 @@ pub enum MockExchangeRequestKind {
         response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
     },
     FetchTrades {
-        response_tx: oneshot::Sender<Vec<Trade<QuoteAsset, InstrumentNameExchange>>>,
+        response_tx: oneshot::Sender<Vec<Trade<InstrumentNameExchange>>>,
         time_since: DateTime<Utc>,
     },
     CancelOrder {

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -15,7 +15,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     index::error::IndexError,
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
@@ -269,8 +269,8 @@ impl AccountEventIndexer {
 
     pub fn trade(
         &self,
-        trade: Trade<QuoteAsset, InstrumentNameExchange>,
-    ) -> Result<Trade<QuoteAsset, InstrumentIndex>, IndexError> {
+        trade: Trade<InstrumentNameExchange>,
+    ) -> Result<Trade<InstrumentIndex>, IndexError> {
         let Trade {
             id,
             order_id,

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -29,7 +29,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
 };
@@ -97,7 +97,7 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     OrderCancelled(OrderResponseCancel<ExchangeKey, AssetKey, InstrumentKey>),
 
     /// [`Order<ExchangeKey, InstrumentKey, Open>`] partial or full-fill.
-    Trade(Trade<QuoteAsset, InstrumentKey>),
+    Trade(Trade<InstrumentKey>),
 }
 
 impl<ExchangeKey, AssetKey, InstrumentKey> AccountEvent<ExchangeKey, AssetKey, InstrumentKey>

--- a/barter-instrument/src/asset/mod.rs
+++ b/barter-instrument/src/asset/mod.rs
@@ -114,19 +114,3 @@ impl From<Asset> for AssetNameInternal {
         value.name_internal
     }
 }
-
-/// Special type that represents a "base" [`Asset`].
-///
-/// Examples: <br>
-/// a) Instrument = btc_usdt_spot, [`BaseAsset`] => btc <br>
-/// b) Instrument = eth_btc_spot, [`BaseAsset`] => eth
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display)]
-pub struct BaseAsset;
-
-/// Special type that represents a "quote" [`Asset`].
-///
-/// Examples: <br>
-/// a) Instrument = btc_usdt_spot, [`QuoteAsset`] => usdt <br>
-/// b) Instrument = eth_btc_spot, [`QuoteAsset`] => btc
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display)]
-pub struct QuoteAsset;

--- a/barter/examples/statistical_trading_summary.rs
+++ b/barter/examples/statistical_trading_summary.rs
@@ -7,18 +7,18 @@ use barter::{
 };
 use barter_execution::{
     balance::{AssetBalance, Balance},
-    trade::{AssetFees, TradeId},
+    trade::TradeId,
 };
 use barter_instrument::{
     Side, Underlying,
-    asset::{AssetIndex, QuoteAsset},
+    asset::AssetIndex,
     exchange::ExchangeId,
     index::IndexedInstruments,
     instrument::{Instrument, InstrumentIndex},
 };
 use barter_integration::snapshot::Snapshot;
 use chrono::{DateTime, Days, Utc};
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, prelude::Zero};
 use rust_decimal_macros::dec;
 use smol_str::SmolStr;
 
@@ -40,7 +40,7 @@ const STARTING_BALANCE_ETH: Balance = Balance {
 
 pub enum ContrivedEvents {
     Balance(Snapshot<AssetBalance<AssetIndex>>),
-    Position(PositionExited<QuoteAsset, InstrumentIndex>),
+    Position(PositionExited<InstrumentIndex>),
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -137,14 +137,8 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             price_entry_average: dec!(1.0),
             quantity_abs_max: dec!(1000.0),
             pnl_realised: dec!(2000.0), // 2000 usdt profit
-            fees_enter: AssetFees {
-                asset: QuoteAsset,
-                fees: dec!(0.0),
-            },
-            fees_exit: AssetFees {
-                asset: QuoteAsset,
-                fees: dec!(0.0),
-            },
+            fees_enter: dec!(0.0),
+            fees_exit: dec!(0.0),
             time_enter: base_time.checked_add_days(Days::new(1)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(2)).unwrap(),
             trades: vec![TradeId(SmolStr::new("1")), TradeId(SmolStr::new("2"))],
@@ -168,8 +162,8 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             price_entry_average: dec!(1.0),
             quantity_abs_max: dec!(2000.0),
             pnl_realised: dec!(1000.0), // 1000 usdt profit
-            fees_enter: AssetFees::default(),
-            fees_exit: AssetFees::default(),
+            fees_enter: Decimal::zero(),
+            fees_exit: Decimal::zero(),
             time_enter: base_time.checked_add_days(Days::new(2)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(3)).unwrap(),
             trades: vec![TradeId(SmolStr::new("3")), TradeId(SmolStr::new("4"))],
@@ -193,8 +187,8 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             price_entry_average: dec!(1.0),
             quantity_abs_max: dec!(2000.0),
             pnl_realised: dec!(-2000.0), // 2000 usdt loss
-            fees_enter: AssetFees::default(),
-            fees_exit: AssetFees::default(),
+            fees_enter: Decimal::zero(),
+            fees_exit: Decimal::zero(),
             time_enter: base_time.checked_add_days(Days::new(4)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(5)).unwrap(),
             trades: vec![TradeId(SmolStr::new("5")), TradeId(SmolStr::new("6"))],
@@ -224,8 +218,8 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             price_entry_average: dec!(1.0),
             quantity_abs_max: dec!(6000.0),
             pnl_realised: dec!(-1000.0), // 1000 usdt loss
-            fees_enter: AssetFees::default(),
-            fees_exit: AssetFees::default(),
+            fees_enter: Decimal::zero(),
+            fees_exit: Decimal::zero(),
             time_enter: base_time.checked_add_days(Days::new(6)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(8)).unwrap(),
             trades: vec![
@@ -253,8 +247,8 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             price_entry_average: dec!(1.0),
             quantity_abs_max: dec!(6000.0),
             pnl_realised: dec!(500.0), // 500 usdt profit
-            fees_enter: AssetFees::default(),
-            fees_exit: AssetFees::default(),
+            fees_enter: Decimal::zero(),
+            fees_exit: Decimal::zero(),
             time_enter: base_time.checked_add_days(Days::new(10)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(11)).unwrap(),
             trades: vec![TradeId(SmolStr::new("10")), TradeId(SmolStr::new("11"))],

--- a/barter/src/engine/mod.rs
+++ b/barter/src/engine/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use barter_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use barter_execution::AccountEvent;
-use barter_instrument::{asset::QuoteAsset, exchange::ExchangeIndex, instrument::InstrumentIndex};
+use barter_instrument::{exchange::ExchangeIndex, instrument::InstrumentIndex};
 use barter_integration::channel::Tx;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -379,7 +379,7 @@ pub enum EngineOutput<
     Commanded(ActionOutput<ExchangeKey, InstrumentKey>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
-    PositionExit(PositionExited<QuoteAsset, InstrumentKey>),
+    PositionExit(PositionExited<InstrumentKey>),
     MarketDisconnect(OnDisconnect),
     AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
 }
@@ -398,7 +398,7 @@ pub enum UpdateTradingStateOutput<OnTradingDisabled> {
 pub enum UpdateFromAccountOutput<OnDisconnect, InstrumentKey = InstrumentIndex> {
     None,
     OnDisconnect(OnDisconnect),
-    PositionExit(PositionExited<QuoteAsset, InstrumentKey>),
+    PositionExit(PositionExited<InstrumentKey>),
 }
 
 /// Output produced by the [`Engine`] updating from an [`MarketStreamEvent`], used to construct
@@ -419,10 +419,10 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 }
 
 impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
-    From<PositionExited<QuoteAsset, InstrumentKey>>
+    From<PositionExited<InstrumentKey>>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
-    fn from(value: PositionExited<QuoteAsset, InstrumentKey>) -> Self {
+    fn from(value: PositionExited<InstrumentKey>) -> Self {
         Self::PositionExit(value)
     }
 }

--- a/barter/src/engine/state/instrument/mod.rs
+++ b/barter/src/engine/state/instrument/mod.rs
@@ -18,7 +18,7 @@ use barter_execution::{
 };
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{
@@ -323,8 +323,8 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     /// - Updating the internal [`TearSheetGenerator`] if a position is exited.
     pub fn update_from_trade(
         &mut self,
-        trade: &Trade<QuoteAsset, InstrumentKey>,
-    ) -> Option<PositionExited<QuoteAsset, InstrumentKey>>
+        trade: &Trade<InstrumentKey>,
+    ) -> Option<PositionExited<InstrumentKey>>
     where
         InstrumentKey: Debug + Clone + PartialEq,
     {

--- a/barter/src/engine/state/mod.rs
+++ b/barter/src/engine/state/mod.rs
@@ -18,7 +18,7 @@ use barter_execution::{
 };
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, QuoteAsset},
+    asset::AssetIndex,
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{Instrument, InstrumentIndex},
@@ -101,10 +101,7 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     ///   [`Health::Healthy`](connectivity::Health::Healthy) if it was not previously.
     /// - Updates the `GlobalData` with the `AccountEvent`.
     /// - Updates the associated `AssetStates` and `InstrumentStates` with the `AccountEvent`.
-    pub fn update_from_account(
-        &mut self,
-        event: &AccountEvent,
-    ) -> Option<PositionExited<QuoteAsset>>
+    pub fn update_from_account(&mut self, event: &AccountEvent) -> Option<PositionExited>
     where
         GlobalData: for<'a> Processor<&'a AccountEvent>,
         InstrumentData: for<'a> Processor<&'a AccountEvent>,

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -189,9 +189,7 @@ pub mod test_utils {
         order::id::{OrderId, StrategyId},
         trade::{AssetFees, Trade, TradeId},
     };
-    use barter_instrument::{
-        Side, asset::QuoteAsset, instrument::name::InstrumentNameInternal, test_utils::asset,
-    };
+    use barter_instrument::{Side, instrument::name::InstrumentNameInternal, test_utils::asset};
     use chrono::{DateTime, Days, TimeDelta, Utc};
     use rust_decimal::Decimal;
 
@@ -235,7 +233,7 @@ pub mod test_utils {
         price: f64,
         quantity: f64,
         fees: f64,
-    ) -> Trade<QuoteAsset, InstrumentNameInternal> {
+    ) -> Trade<InstrumentNameInternal> {
         Trade {
             id: TradeId::new("trade_id"),
             order_id: OrderId::new("order_id"),
@@ -245,10 +243,7 @@ pub mod test_utils {
             side,
             price: price.try_into().unwrap(),
             quantity: quantity.try_into().unwrap(),
-            fees: AssetFees {
-                asset: QuoteAsset,
-                fees: fees.try_into().unwrap(),
-            },
+            fees: AssetFees::quote(fees.try_into().unwrap()),
         }
     }
 

--- a/barter/src/logging.rs
+++ b/barter/src/logging.rs
@@ -33,6 +33,7 @@ pub fn init_json_logging() {
         .init()
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct AuditSpanFilter;
 
 impl<S> tracing_subscriber::layer::Layer<S> for AuditSpanFilter

--- a/barter/src/statistic/summary/instrument.rs
+++ b/barter/src/statistic/summary/instrument.rs
@@ -67,9 +67,9 @@ impl TearSheetGenerator {
     }
 
     /// Update the [`TearSheetGenerator`] from the next [`PositionExited`].
-    pub fn update_from_position<AssetKey, InstrumentKey>(
+    pub fn update_from_position<InstrumentKey>(
         &mut self,
-        position: &PositionExited<AssetKey, InstrumentKey>,
+        position: &PositionExited<InstrumentKey>,
     ) {
         self.time_engine_now = position.time_exit;
         self.pnl_returns.update(position);

--- a/barter/src/statistic/summary/mod.rs
+++ b/barter/src/statistic/summary/mod.rs
@@ -114,10 +114,8 @@ impl TradingSummaryGenerator {
     }
 
     /// Update the [`TradingSummaryGenerator`] from the next [`PositionExited`].
-    pub fn update_from_position<AssetKey, InstrumentKey>(
-        &mut self,
-        position: &PositionExited<AssetKey, InstrumentKey>,
-    ) where
+    pub fn update_from_position<InstrumentKey>(&mut self, position: &PositionExited<InstrumentKey>)
+    where
         Self: InstrumentTearSheetManager<InstrumentKey>,
     {
         if self.time_engine_now < position.time_exit {

--- a/barter/src/statistic/summary/pnl.rs
+++ b/barter/src/statistic/summary/pnl.rs
@@ -40,10 +40,7 @@ pub struct PnLReturns {
 
 impl PnLReturns {
     /// Update the `PnLReturns` from the next [`PositionExited`].
-    pub fn update<AssetKey, InstrumentKey>(
-        &mut self,
-        position: &PositionExited<AssetKey, InstrumentKey>,
-    ) {
+    pub fn update<InstrumentKey>(&mut self, position: &PositionExited<InstrumentKey>) {
         self.pnl_raw += position.pnl_realised;
 
         let pnl_return = calculate_pnl_return(

--- a/barter/src/strategy/close_positions.rs
+++ b/barter/src/strategy/close_positions.rs
@@ -99,9 +99,9 @@ where
 /// provided [`Position`].
 ///
 /// For example, if [`Position`] is LONG by 100, build a market order request to sell 100.
-pub fn build_ioc_market_order_to_close_position<ExchangeKey, AssetKey, InstrumentKey>(
+pub fn build_ioc_market_order_to_close_position<ExchangeKey, InstrumentKey>(
     exchange: ExchangeKey,
-    position: &Position<AssetKey, InstrumentKey>,
+    position: &Position<InstrumentKey>,
     strategy_id: StrategyId,
     price: Decimal,
     gen_cid: impl Fn() -> ClientOrderId,

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -423,8 +423,8 @@ fn test_engine_process_engine_event_with_audit() {
                 price_entry_average: dec!(10_000.0),
                 quantity_abs_max: dec!(1.0),
                 pnl_realised: dec!(7000.0), // (-10k entry - 1k fees)+(20k exit - 2k fees) = 7k
-                fees_enter: AssetFees::quote_fees(dec!(1_000.0)),
-                fees_exit: AssetFees::quote_fees(dec!(2_000.0)),
+                fees_enter: dec!(1_000.0),
+                fees_exit: dec!(2_000.0),
                 time_enter: time_plus_days(STARTING_TIMESTAMP, 2),
                 time_exit: time_plus_days(STARTING_TIMESTAMP, 3),
                 trades: vec![gen_trade_id(0), gen_trade_id(0)],
@@ -603,8 +603,8 @@ fn test_engine_process_engine_event_with_audit() {
                 price_entry_average: dec!(0.1),
                 quantity_abs_max: dec!(1.0),
                 pnl_realised: dec!(-0.065), // 0.05 - 0.01 - 0.01 entry fees - 0.005 exit fees
-                fees_enter: AssetFees::quote_fees(dec!(0.01)), // 0.01 btc
-                fees_exit: AssetFees::quote_fees(dec!(0.005)), // 0.005 btc
+                fees_enter: dec!(0.01),     // 0.01 btc
+                fees_exit: dec!(0.005),     // 0.005 btc
                 time_enter: time_plus_days(STARTING_TIMESTAMP, 2),
                 time_exit: time_plus_days(STARTING_TIMESTAMP, 5),
                 trades: vec![gen_trade_id(1), gen_trade_id(1)],
@@ -962,7 +962,7 @@ fn account_event_trade(
             side,
             price: Decimal::try_from(price).unwrap(),
             quantity: Decimal::try_from(quantity).unwrap(),
-            fees: AssetFees::quote_fees(
+            fees: AssetFees::quote(
                 Decimal::try_from(price * quantity * QUOTE_FEES_PERCENT).unwrap(),
             ),
         }),


### PR DESCRIPTION
Change struct from 
```
pub struct AssetFees<AssetKey> {
    pub asset: AssetKey,
    pub fees: Decimal,
}
```
to
```
pub enum AssetFees {
    Base(Decimal),
    Quote(Decimal),
}
```

This is needed because in some cases you pay the fee with base asset and quote asset. Like when trading on the spot market. You always pay in the receiving asset. This couldn't be represented with the current abstraction. The drawback of the current abstraction can be seen in [this](https://github.com/barter-rs/barter-rs/pull/224#discussion_r2430510138) PR.

The `struct Position` was changed to always hold the fee in the quote asset. In cases when we receive a trade that has a fee in base. We convert that fee to a quote and record it.