### PR TITLE
fix(bybit): handle pong responses without propagating deserialization errors

### DIFF
--- a/barter-data/src/exchange/bybit/book/l1.rs
+++ b/barter-data/src/exchange/bybit/book/l1.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use crate::{
     books::Level,
     event::{MarketEvent, MarketIter},
+    exchange::bybit::message::BybitWsMessage,
     subscription::book::OrderBookL1,
 };
 
@@ -15,8 +16,12 @@ where
     InstrumentKey: Clone,
 {
     fn from(
-        (exchange, instrument, book): (ExchangeId, InstrumentKey, BybitOrderBookMessage),
+        (exchange, instrument, msg): (ExchangeId, InstrumentKey, BybitOrderBookMessage),
     ) -> Self {
+        let BybitWsMessage::Payload(book) = msg else {
+            return Self(vec![]);
+        };
+
         let best_ask = book.data.asks.first().copied().map(Level::from);
         let best_bid = book.data.bids.first().copied().map(Level::from);
 

--- a/barter-data/src/exchange/bybit/book/l2.rs
+++ b/barter-data/src/exchange/bybit/book/l2.rs
@@ -6,7 +6,11 @@ use crate::{
     event::{MarketEvent, MarketIter},
     exchange::{
         Connector,
-        bybit::{Bybit, message::BybitPayloadKind, spot::BybitSpot},
+        bybit::{
+            Bybit,
+            message::{BybitPayload, BybitPayloadKind, BybitWsMessage},
+            spot::BybitSpot,
+        },
     },
     subscription::{
         Map,
@@ -66,6 +70,11 @@ where
     type OutputIter = Vec<Result<Self::Output, Self::Error>>;
 
     fn transform(&mut self, input: Self::Input) -> Self::OutputIter {
+        // Silently discard control messages (pong, subscribe ack) — they carry no market data.
+        let BybitWsMessage::Payload(input) = input else {
+            return vec![];
+        };
+
         // Determine if the message has an identifiable SubscriptionId
         let subscription_id = match input.id() {
             Some(subscription_id) => subscription_id,
@@ -88,7 +97,7 @@ where
             return MarketIter::<InstrumentKey, OrderBookEvent>::from((
                 BybitSpot::ID,
                 instrument.key.clone(),
-                input,
+                BybitWsMessage::Payload(input),
             ))
             .0;
         }
@@ -109,7 +118,7 @@ where
         MarketIter::<InstrumentKey, OrderBookEvent>::from((
             BybitSpot::ID,
             instrument.key.clone(),
-            valid_update,
+            BybitWsMessage::Payload(valid_update),
         ))
         .0
     }
@@ -123,8 +132,8 @@ struct BybitOrderBookL2Sequencer {
 impl BybitOrderBookL2Sequencer {
     pub fn validate_sequence(
         &mut self,
-        update: BybitOrderBookMessage,
-    ) -> Result<Option<BybitOrderBookMessage>, DataError> {
+        update: BybitPayload<super::BybitOrderBookInner>,
+    ) -> Result<Option<BybitPayload<super::BybitOrderBookInner>>, DataError> {
         // Each new update_id should be `last_update_id + 1`
         if update.data.update_id != self.last_update_id + 1 {
             return Err(DataError::InvalidSequence {

--- a/barter-data/src/exchange/bybit/book/mod.rs
+++ b/barter-data/src/exchange/bybit/book/mod.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use super::message::{BybitPayload, BybitPayloadKind};
+use super::message::{BybitPayloadKind, BybitWsMessage};
 
 /// Level 1 OrderBook types.
 pub mod l1;
@@ -16,8 +16,8 @@ pub mod l1;
 /// Level 2 OrderBook types.
 pub mod l2;
 
-/// Terse type alias for an [`BybitOrderBookMessage`] OrderBook WebSocket message.
-pub type BybitOrderBookMessage = BybitPayload<BybitOrderBookInner>;
+/// Terse type alias for a Bybit OrderBook WebSocket message.
+pub type BybitOrderBookMessage = BybitWsMessage<BybitOrderBookInner>;
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct BybitOrderBookInner {
@@ -38,8 +38,12 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BybitOrderBookMessage)>
     for MarketIter<InstrumentKey, OrderBookEvent>
 {
     fn from(
-        (exchange, instrument, message): (ExchangeId, InstrumentKey, BybitOrderBookMessage),
+        (exchange, instrument, msg): (ExchangeId, InstrumentKey, BybitOrderBookMessage),
     ) -> Self {
+        let BybitWsMessage::Payload(message) = msg else {
+            return Self(vec![]);
+        };
+
         let orderbook = OrderBook::new(
             message.data.sequence,
             Some(message.time),

--- a/barter-data/src/exchange/bybit/message.rs
+++ b/barter-data/src/exchange/bybit/message.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::{Identifier, exchange::bybit::channel::BybitChannel};
+use crate::{Identifier, exchange::bybit::{channel::BybitChannel, subscription::BybitResponse}};
 use barter_integration::subscription::SubscriptionId;
 use chrono::{DateTime, Utc};
 use serde::{
@@ -92,12 +92,42 @@ impl<T> Identifier<Option<SubscriptionId>> for BybitPayload<T> {
     }
 }
 
+/// Wraps either a market data [`BybitPayload<T>`] or a control message [`BybitResponse`]
+/// (pong, subscribe acknowledgement).
+///
+/// Bybit responds to application-level pings with a text frame:
+/// `{"success":true,"ret_msg":"pong","conn_id":"...","op":"ping"}`
+///
+/// Without this wrapper the parser would attempt to deserialise that response as
+/// `BybitPayload<T>`, fail (no `topic` field), and propagate a stream error every 5 seconds.
+/// By using `#[serde(untagged)]` the pong is captured as `Control` and silently discarded by
+/// returning `None` from [`Identifier::id`].
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BybitWsMessage<T> {
+    Payload(BybitPayload<T>),
+    Control(BybitResponse),
+}
+
+impl<T> Identifier<Option<SubscriptionId>> for BybitWsMessage<T> {
+    fn id(&self) -> Option<SubscriptionId> {
+        match self {
+            BybitWsMessage::Payload(payload) => payload.id(),
+            BybitWsMessage::Control(_) => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
     mod de {
-        use crate::exchange::bybit::subscription::{BybitResponse, BybitReturnMessage};
-        use barter_integration::error::SocketError;
+        use crate::exchange::bybit::{
+            message::{BybitPayload, BybitPayloadKind, BybitWsMessage},
+            subscription::{BybitResponse, BybitReturnMessage},
+        };
+        use barter_integration::{error::SocketError, subscription::SubscriptionId};
+        use smol_str::ToSmolStr;
 
         #[test]
         fn test_bybit_pong() {
@@ -130,11 +160,62 @@ mod tests {
                     (Ok(actual), Ok(expected)) => {
                         assert_eq!(actual, expected, "TC{} failed", index)
                     }
-                    (Err(_), Err(_)) => {
-                        // Test passed
-                    }
+                    (Err(_), Err(_)) => {}
                     (actual, expected) => {
-                        // Test failed
+                        panic!(
+                            "TC{index} failed because actual != expected. \nActual: {actual:?}\nExpected: {expected:?}\n"
+                        );
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_bybit_ws_message_pong_deserialises_as_control() {
+            struct TestCase {
+                input: &'static str,
+                expected: Result<BybitWsMessage<()>, SocketError>,
+            }
+
+            let tests = vec![
+                // TC0: pong deserialises as Control, not as a parse error
+                TestCase {
+                    input: r#"{"success":true,"ret_msg":"pong","conn_id":"abc","op":"ping"}"#,
+                    expected: Ok(BybitWsMessage::Control(BybitResponse {
+                        success: true,
+                        ret_msg: BybitReturnMessage::Pong,
+                    })),
+                },
+                // TC1: subscribe ack deserialises as Control
+                TestCase {
+                    input: r#"{"success":true,"ret_msg":"subscribe","conn_id":"abc","op":"subscribe"}"#,
+                    expected: Ok(BybitWsMessage::Control(BybitResponse {
+                        success: true,
+                        ret_msg: BybitReturnMessage::Subscribe,
+                    })),
+                },
+                // TC2: market data payload deserialises as Payload
+                TestCase {
+                    input: r#"{"topic":"publicTrade.BTCUSDT","type":"snapshot","ts":1672304486868,"data":null}"#,
+                    expected: Ok(BybitWsMessage::Payload(BybitPayload {
+                        subscription_id: SubscriptionId("publicTrade|BTCUSDT".to_smolstr()),
+                        kind: BybitPayloadKind::Snapshot,
+                        time: barter_integration::serde::de::datetime_utc_from_epoch_duration(
+                            std::time::Duration::from_millis(1672304486868),
+                        ),
+                        data: (),
+                    })),
+                },
+            ];
+
+            for (index, test) in tests.into_iter().enumerate() {
+                let actual = serde_json::from_str::<BybitWsMessage<()>>(test.input);
+                match (actual, test.expected) {
+                    (Ok(actual), Ok(expected)) => {
+                        assert_eq!(actual, expected, "TC{index} failed")
+                    }
+                    (Err(_), Err(_)) => {}
+                    (actual, expected) => {
                         panic!(
                             "TC{index} failed because actual != expected. \nActual: {actual:?}\nExpected: {expected:?}\n"
                         );

--- a/barter-data/src/exchange/bybit/trade.rs
+++ b/barter-data/src/exchange/bybit/trade.rs
@@ -1,14 +1,14 @@
 use crate::{
     event::{MarketEvent, MarketIter},
-    exchange::bybit::message::BybitPayload,
+    exchange::bybit::message::{BybitWsMessage},
     subscription::trade::PublicTrade,
 };
 use barter_instrument::{Side, exchange::ExchangeId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Terse type alias for an [`BybitTrade`](BybitTradeInner) real-time trades WebSocket message.
-pub type BybitTrade = BybitPayload<Vec<BybitTradeInner>>;
+/// Terse type alias for a Bybit real-time trades WebSocket message.
+pub type BybitTrade = BybitWsMessage<Vec<BybitTradeInner>>;
 
 /// ### Raw Payload Examples
 /// See docs: <https://bybit-exchange.github.io/docs/v5/websocket/public/trade>
@@ -58,7 +58,10 @@ pub struct BybitTradeInner {
 impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, BybitTrade)>
     for MarketIter<InstrumentKey, PublicTrade>
 {
-    fn from((exchange, instrument, trades): (ExchangeId, InstrumentKey, BybitTrade)) -> Self {
+    fn from((exchange, instrument, msg): (ExchangeId, InstrumentKey, BybitTrade)) -> Self {
+        let BybitWsMessage::Payload(trades) = msg else {
+            return Self(vec![]);
+        };
         Self(
             trades
                 .data
@@ -87,7 +90,7 @@ mod tests {
     use super::*;
 
     mod de {
-        use crate::exchange::bybit::message::BybitPayloadKind;
+        use crate::exchange::bybit::message::{BybitPayload, BybitPayloadKind, BybitWsMessage};
 
         use super::*;
         use barter_integration::{
@@ -234,7 +237,7 @@ mod tests {
                             ]
                         }
                     "#,
-                    expected: Ok(BybitTrade {
+                    expected: Ok(BybitWsMessage::Payload(BybitPayload {
                         subscription_id: SubscriptionId("publicTrade|BTCUSDT".to_smolstr()),
                         kind: BybitPayloadKind::Snapshot,
                         time: datetime_utc_from_epoch_duration(Duration::from_millis(
@@ -262,7 +265,7 @@ mod tests {
                                 id: "20f43950-d8dd-5b31-9112-a178eb6023af".to_string(),
                             },
                         ],
-                    }),
+                    })),
                 },
                 // TC1: input BybitTrade is invalid w/ no subscription_id
                 TestCase {


### PR DESCRIPTION
## Problem

Bybit responds to application-level pings (sent every 5 seconds via `ping_interval()`) with a **text frame**:

```json
{"success": true, "ret_msg": "pong", "conn_id": "...", "op": "ping"}
```

`WebSocketSerdeParser` routes all text frames through `process_text()`, which attempts to deserialize the message as `BybitPayload<T>`. This fails because the pong response has no `topic` field, returning `Some(Err(SocketError::Deserialise))` from the parser.

`ExchangeStream::poll_next()` propagates this as a stream error item every 5 seconds:

```
Some(Err(err)) => return Poll::Ready(Some(Err(err.into())))
```

This is a library-internal inconsistency: barter-data sends the ping itself, yet cannot handle the exchange's reply.

## Fix

Introduce `BybitWsMessage<T>`, an `#[serde(untagged)]` enum that wraps either a market data payload or a control response:

```rust
#[serde(untagged)]
pub enum BybitWsMessage<T> {
    Payload(BybitPayload<T>),
    Control(BybitResponse),   // pong, subscribe ack
}
```

`Identifier::id` returns `None` for the `Control` variant, so all transformers silently discard pong/subscribe messages without emitting stream errors.

The type aliases `BybitTrade` and `BybitOrderBookMessage` now resolve to `BybitWsMessage<T>`, keeping the change self-contained within the Bybit module.

## Changed files

- `message.rs` — add `BybitWsMessage<T>` and its `Identifier` impl; add tests
- `trade.rs` — update `BybitTrade` alias and `From` impl
- `book/mod.rs` — update `BybitOrderBookMessage` alias and `From` impl
- `book/l1.rs` — update `From` impl
- `book/l2.rs` — update `BybitOrderBooksL2Transformer` to extract payload before processing

## Tests

New test `test_bybit_ws_message_pong_deserialises_as_control` verifies:
- pong → `Control(BybitResponse { ret_msg: Pong })`
- subscribe ack → `Control(BybitResponse { ret_msg: Subscribe })`
- market data → `Payload(BybitPayload { ... })`

All 60 existing tests continue to pass.