### PR TITLE
feat: order management rework

### DIFF
--- a/barter-execution/Cargo.toml
+++ b/barter-execution/Cargo.toml
@@ -39,6 +39,5 @@ serde = { workspace = true, features = ["derive"] }
 # Misc
 rand = { workspace = true }
 chrono = { workspace = true, features = ["serde"]}
-itertools = { workspace = true }
 derive_more = { workspace = true, features = ["constructor", "from", "display"]}
 

--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -5,8 +5,11 @@ use crate::{
     error::{ConnectivityError, UnindexedClientError, UnindexedOrderError},
     exchange::mock::request::MockExchangeRequest,
     order::{
-        Order, OrderEvent, OrderKey,
-        request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
+        Order, OrderEvent, OrderKey, UnindexedOrderSnapshot,
+        request::{
+            OrderRequestCancel, OrderRequestOpen, OrderRequestSnapshot,
+            UnindexedOrderResponseCancel,
+        },
         state::Open,
     },
     trade::Trade,
@@ -90,7 +93,7 @@ where
 
 impl<FnTime> ExecutionClient for MockExecution<FnTime>
 where
-    FnTime: Fn() -> DateTime<Utc> + Clone + Sync,
+    FnTime: Fn() -> DateTime<Utc> + Clone + Send + Sync,
 {
     const EXCHANGE: ExchangeId = ExchangeId::Mock;
     type Config = MockExecutionClientConfig<FnTime>;
@@ -261,17 +264,17 @@ where
         })
     }
 
-    async fn fetch_open_orders(
+    async fn fetch_order_snapshot(
         &self,
-        instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError> {
+        request: OrderRequestSnapshot<ExchangeId, InstrumentNameExchange>,
+    ) -> Result<UnindexedOrderSnapshot, UnindexedClientError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         self.request_tx
-            .send(MockExchangeRequest::fetch_orders_open(
+            .send(MockExchangeRequest::fetch_order_snapshot(
                 self.time_request(),
-                instruments.to_vec(),
                 response_tx,
+                request.clone(),
             ))
             .map_err(|_| {
                 UnindexedClientError::Connectivity(ConnectivityError::ExchangeOffline(

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -3,8 +3,11 @@ use crate::{
     balance::AssetBalance,
     error::{UnindexedClientError, UnindexedOrderError},
     order::{
-        Order,
-        request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
+        Order, UnindexedOrderSnapshot,
+        request::{
+            OrderRequestCancel, OrderRequestOpen, OrderRequestSnapshot,
+            UnindexedOrderResponseCancel,
+        },
         state::Open,
     },
     trade::Trade,
@@ -15,7 +18,7 @@ use barter_instrument::{
     instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
-use futures::Stream;
+use futures::{FutureExt, Stream, future::BoxFuture};
 use std::future::Future;
 
 mod binance;
@@ -80,17 +83,30 @@ where
         )
     }
 
+    fn fetch_order_snapshot(
+        &self,
+        request: OrderRequestSnapshot<ExchangeId, InstrumentNameExchange>,
+    ) -> impl Future<Output = Result<UnindexedOrderSnapshot, UnindexedClientError>> + Send;
+
+    /// Futures should be returned in the same order as the requests.
+    fn fetch_order_snapshots(
+        &self,
+        requests: impl IntoIterator<Item = OrderRequestSnapshot<ExchangeId, InstrumentNameExchange>>,
+    ) -> impl Iterator<Item = BoxFuture<'_, Result<UnindexedOrderSnapshot, UnindexedClientError>>>
+    where
+        Self: Send,
+    {
+        let client = self.clone();
+        requests.into_iter().map(move |request| {
+            let client = client.clone();
+            async move { client.fetch_order_snapshot(request).await }.boxed()
+        })
+    }
+
     fn fetch_balances(
         &self,
         assets: &[AssetNameExchange],
     ) -> impl Future<Output = Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError>>;
-
-    fn fetch_open_orders(
-        &self,
-        instruments: &[InstrumentNameExchange],
-    ) -> impl Future<
-        Output = Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError>,
-    >;
 
     fn fetch_trades(
         &self,

--- a/barter-execution/src/exchange/mock/account.rs
+++ b/barter-execution/src/exchange/mock/account.rs
@@ -4,7 +4,7 @@ use crate::{
     order::{
         Order,
         id::ClientOrderId,
-        state::{ActiveOrderState, Cancelled, InactiveOrderState, Open, OrderState},
+        state::{Cancelled, Open, OrderState},
     },
     trade::Trade,
 };
@@ -92,7 +92,7 @@ impl From<UnindexedAccountSnapshot> for AccountState {
             |(mut orders_open, mut orders_cancelled), snapshot| {
                 for order in snapshot.orders {
                     match order.state {
-                        OrderState::Active(ActiveOrderState::Open(open)) => {
+                        OrderState::Open(open) => {
                             orders_open.insert(
                                 order.key.cid.clone(),
                                 Order {
@@ -106,7 +106,7 @@ impl From<UnindexedAccountSnapshot> for AccountState {
                                 },
                             );
                         }
-                        OrderState::Inactive(InactiveOrderState::Cancelled(cancelled)) => {
+                        OrderState::Cancelled(cancelled) => {
                             orders_cancelled.insert(
                                 order.key.cid.clone(),
                                 Order {

--- a/barter-execution/src/exchange/mock/account.rs
+++ b/barter-execution/src/exchange/mock/account.rs
@@ -4,7 +4,7 @@ use crate::{
     order::{
         Order,
         id::ClientOrderId,
-        state::{Cancelled, Open},
+        state::{Cancelled, Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -60,6 +60,20 @@ impl AccountState {
         self.trades
             .iter()
             .filter(move |trade| trade.time_exchange >= time_since)
+    }
+
+    pub fn find_order(
+        &self,
+        cid: &ClientOrderId,
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
+        self.orders_open
+            .get(cid)
+            .map(|o| o.clone().map_state(UnindexedOrderState::Open))
+            .or_else(|| {
+                self.orders_cancelled
+                    .get(cid)
+                    .map(|o| o.clone().map_state(UnindexedOrderState::Cancelled))
+            })
     }
 
     pub fn balance_mut(

--- a/barter-execution/src/exchange/mock/account.rs
+++ b/barter-execution/src/exchange/mock/account.rs
@@ -4,7 +4,7 @@ use crate::{
     order::{
         Order,
         id::ClientOrderId,
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Open},
     },
     trade::Trade,
 };
@@ -76,62 +76,17 @@ impl AccountState {
 
 impl From<UnindexedAccountSnapshot> for AccountState {
     fn from(value: UnindexedAccountSnapshot) -> Self {
-        let UnindexedAccountSnapshot {
-            exchange: _,
-            balances,
-            instruments,
-        } = value;
+        let UnindexedAccountSnapshot { exchange: _, balances } = value;
 
         let balances = balances
             .into_iter()
             .map(|asset_balance| (asset_balance.asset.clone(), asset_balance))
             .collect();
 
-        let (orders_open, orders_cancelled) = instruments.into_iter().fold(
-            (FnvHashMap::default(), FnvHashMap::default()),
-            |(mut orders_open, mut orders_cancelled), snapshot| {
-                for order in snapshot.orders {
-                    match order.state {
-                        OrderState::Open(open) => {
-                            orders_open.insert(
-                                order.key.cid.clone(),
-                                Order {
-                                    key: order.key,
-                                    side: order.side,
-                                    price: order.price,
-                                    quantity: order.quantity,
-                                    kind: order.kind,
-                                    time_in_force: order.time_in_force,
-                                    state: open,
-                                },
-                            );
-                        }
-                        OrderState::Cancelled(cancelled) => {
-                            orders_cancelled.insert(
-                                order.key.cid.clone(),
-                                Order {
-                                    key: order.key,
-                                    side: order.side,
-                                    price: order.price,
-                                    quantity: order.quantity,
-                                    kind: order.kind,
-                                    time_in_force: order.time_in_force,
-                                    state: cancelled,
-                                },
-                            );
-                        }
-                        _ => {}
-                    }
-                }
-
-                (orders_open, orders_cancelled)
-            },
-        );
-
         Self {
             balances,
-            orders_open,
-            orders_cancelled,
+            orders_open: FnvHashMap::default(),
+            orders_cancelled: FnvHashMap::default(),
             trades: vec![],
         }
     }

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -8,10 +8,10 @@ use crate::{
         request::{MockExchangeRequest, MockExchangeRequestKind},
     },
     order::{
-        Order, OrderKind,
+        Order, OrderKind, TimeInForce,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen},
-        state::{Cancelled, Open},
+        state::{Cancelled, FullyFilled, Open, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -89,18 +89,6 @@ impl MockExchange {
                         .collect();
                     self.respond_with_latency(response_tx, balances);
                 }
-                MockExchangeRequestKind::FetchOrdersOpen {
-                    response_tx,
-                    instruments,
-                } => {
-                    let orders_open = self
-                        .account
-                        .orders_open()
-                        .filter(|order| instruments.contains(&order.key.instrument))
-                        .cloned()
-                        .collect();
-                    self.respond_with_latency(response_tx, orders_open);
-                }
                 MockExchangeRequestKind::FetchTrades {
                     response_tx,
                     time_since,
@@ -129,6 +117,21 @@ impl MockExchange {
                         self.account.ack_trade(notifications.trade.clone());
                         self.send_notifications_with_latency(notifications);
                     }
+                }
+                MockExchangeRequestKind::FetchOrderSnapshot { response_tx, request } => {
+                    let response = self.account.find_order(&request.key.cid).unwrap_or_else(|| {
+                        // Order not found - assume FullyFilled (mock fills market orders immediately)
+                        Order {
+                            key: request.key,
+                            side: Side::Buy,
+                            price: Decimal::ZERO,
+                            quantity: Decimal::ZERO,
+                            kind: OrderKind::Market,
+                            time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+                            state: UnindexedOrderState::FullyFilled(FullyFilled),
+                        }
+                    });
+                    self.respond_with_latency(response_tx, response);
                 }
             }
         }

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -8,10 +8,10 @@ use crate::{
         request::{MockExchangeRequest, MockExchangeRequestKind},
     },
     order::{
-        Order, OrderKind, UnindexedOrder,
+        Order, OrderKind,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen},
-        state::{Cancelled, Open},
+        state::{Cancelled, Open, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -158,13 +158,13 @@ impl MockExchange {
             .account
             .orders_open()
             .cloned()
-            .map(UnindexedOrder::from);
+            .map(|order| order.map_state(UnindexedOrderState::Open));
 
         let orders_cancelled = self
             .account
             .orders_cancelled()
             .cloned()
-            .map(UnindexedOrder::from);
+            .map(|order| order.map_state(UnindexedOrderState::Cancelled));
 
         let orders_all = orders_open.chain(orders_cancelled);
         let orders_all = orders_all.sorted_unstable_by_key(|order| order.key.instrument.clone());

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AccountEventKind, InstrumentAccountSnapshot, UnindexedAccountEvent, UnindexedAccountSnapshot,
+    AccountEventKind, UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::mock::MockExecutionConfig,
     error::{ApiError, UnindexedApiError, UnindexedOrderError},
@@ -11,7 +11,7 @@ use crate::{
         Order, OrderKind,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen},
-        state::{Cancelled, Open, UnindexedOrderState},
+        state::{Cancelled, Open},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -25,7 +25,6 @@ use barter_integration::collection::snapshot::Snapshot;
 use chrono::{DateTime, TimeDelta, Utc};
 use fnv::FnvHashMap;
 use futures::stream::BoxStream;
-use itertools::Itertools;
 use rust_decimal::Decimal;
 use smol_str::ToSmolStr;
 use std::fmt::Debug;
@@ -152,36 +151,9 @@ impl MockExchange {
     }
 
     pub fn account_snapshot(&self) -> UnindexedAccountSnapshot {
-        let balances = self.account.balances().cloned().collect();
-
-        let orders_open = self
-            .account
-            .orders_open()
-            .cloned()
-            .map(|order| order.map_state(UnindexedOrderState::Open));
-
-        let orders_cancelled = self
-            .account
-            .orders_cancelled()
-            .cloned()
-            .map(|order| order.map_state(UnindexedOrderState::Cancelled));
-
-        let orders_all = orders_open.chain(orders_cancelled);
-        let orders_all = orders_all.sorted_unstable_by_key(|order| order.key.instrument.clone());
-        let orders_by_instrument = orders_all.chunk_by(|order| order.key.instrument.clone());
-
-        let instruments = orders_by_instrument
-            .into_iter()
-            .map(|(instrument, orders)| InstrumentAccountSnapshot {
-                instrument,
-                orders: orders.into_iter().collect(),
-            })
-            .collect();
-
         UnindexedAccountSnapshot {
             exchange: self.exchange,
-            balances,
-            instruments,
+            balances: self.account.balances().cloned().collect(),
         }
     }
 

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -4,8 +4,11 @@ use crate::{
     error::UnindexedOrderError,
     order::{
         Order,
-        request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        request::{
+            OrderRequestCancel, OrderRequestOpen, UnindexedOrderRequestSnapshot,
+            UnindexedOrderResponseCancel,
+        },
+        state::{Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -48,20 +51,6 @@ impl MockExchangeRequest {
             MockExchangeRequestKind::FetchBalances {
                 response_tx,
                 assets,
-            },
-        )
-    }
-
-    pub fn fetch_orders_open(
-        time_request: DateTime<Utc>,
-        instruments: Vec<InstrumentNameExchange>,
-        response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
-    ) -> Self {
-        Self::new(
-            time_request,
-            MockExchangeRequestKind::FetchOrdersOpen {
-                response_tx,
-                instruments,
             },
         )
     }
@@ -109,6 +98,22 @@ impl MockExchangeRequest {
             },
         )
     }
+
+    pub fn fetch_order_snapshot(
+        time_request: DateTime<Utc>,
+        response_tx: oneshot::Sender<
+            Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
+        >,
+        request: UnindexedOrderRequestSnapshot,
+    ) -> Self {
+        Self::new(
+            time_request,
+            MockExchangeRequestKind::FetchOrderSnapshot {
+                response_tx,
+                request,
+            },
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -119,10 +124,6 @@ pub enum MockExchangeRequestKind {
     FetchBalances {
         assets: Vec<AssetNameExchange>,
         response_tx: oneshot::Sender<Vec<AssetBalance<AssetNameExchange>>>,
-    },
-    FetchOrdersOpen {
-        instruments: Vec<InstrumentNameExchange>,
-        response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
     },
     FetchTrades {
         response_tx: oneshot::Sender<Vec<Trade<QuoteAsset, InstrumentNameExchange>>>,
@@ -137,5 +138,10 @@ pub enum MockExchangeRequestKind {
             Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
         >,
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
+    },
+    FetchOrderSnapshot {
+        response_tx:
+            oneshot::Sender<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>,
+        request: UnindexedOrderRequestSnapshot,
     },
 }

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AccountEvent, AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot,
+    AccountEvent, AccountEventKind, AccountSnapshot,
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
     error::{
@@ -71,11 +71,7 @@ impl AccountEventIndexer {
         &self,
         snapshot: UnindexedAccountSnapshot,
     ) -> Result<AccountSnapshot, IndexError> {
-        let UnindexedAccountSnapshot {
-            exchange,
-            balances,
-            instruments,
-        } = snapshot;
+        let UnindexedAccountSnapshot { exchange, balances } = snapshot;
 
         let exchange = self.map.find_exchange_index(exchange)?;
 
@@ -84,27 +80,7 @@ impl AccountEventIndexer {
             .map(|balance| self.asset_balance(balance))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let instruments = instruments
-            .into_iter()
-            .map(|snapshot| {
-                let InstrumentAccountSnapshot { instrument, orders } = snapshot;
-
-                let instrument = self.map.find_instrument_index(&instrument)?;
-
-                let orders = orders
-                    .into_iter()
-                    .map(|order| self.order_snapshot(order))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(InstrumentAccountSnapshot { instrument, orders })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(AccountSnapshot {
-            exchange,
-            balances,
-            instruments,
-        })
+        Ok(AccountSnapshot { exchange, balances })
     }
 
     pub fn asset_balance(

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -9,8 +9,7 @@ use crate::{
     map::ExecutionInstrumentMap,
     order::{
         Order, OrderEvent, OrderKey, OrderSnapshot, UnindexedOrderKey, UnindexedOrderSnapshot,
-        request::OrderResponseCancel,
-        state::{InactiveOrderState, OrderState, UnindexedOrderState},
+        request::OrderResponseCancel, state::OrderState,
     },
     trade::Trade,
 };
@@ -143,20 +142,17 @@ impl AccountEventIndexer {
         let key = self.order_key(key)?;
 
         let state = match state {
-            UnindexedOrderState::Active(active) => OrderState::Active(active),
-            UnindexedOrderState::Inactive(inactive) => match inactive {
-                InactiveOrderState::OpenFailed(failed) => match failed {
-                    OrderError::Rejected(rejected) => {
-                        OrderState::inactive(OrderError::Rejected(self.api_error(rejected)?))
-                    }
-                    OrderError::Connectivity(error) => {
-                        OrderState::inactive(OrderError::Connectivity(error))
-                    }
-                },
-                InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
-                InactiveOrderState::FullyFilled => OrderState::fully_filled(),
-                InactiveOrderState::Expired => OrderState::expired(),
-            },
+            OrderState::OpenInFlight(open_in_flight) => OrderState::OpenInFlight(open_in_flight),
+            OrderState::Open(open) => OrderState::Open(open),
+            OrderState::CancelInFlight(cancel_in_flight) => {
+                OrderState::CancelInFlight(cancel_in_flight)
+            }
+            OrderState::Cancelled(cancelled) => OrderState::Cancelled(cancelled),
+            OrderState::FullyFilled(fully_filled) => OrderState::FullyFilled(fully_filled),
+            OrderState::OpenFailed(open_failed) => {
+                OrderState::OpenFailed(self.order_error(open_failed)?)
+            }
+            OrderState::Expired(expired) => OrderState::Expired(expired),
         };
 
         Ok(Order {

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -25,7 +25,7 @@
 
 use crate::{
     balance::AssetBalance,
-    order::{Order, OrderSnapshot, request::OrderResponseCancel},
+    order::{Order, request::OrderResponseCancel},
     trade::Trade,
 };
 use barter_instrument::{
@@ -53,10 +53,9 @@ pub mod trade;
 pub type UnindexedAccountEvent =
     AccountEvent<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
 
-/// Convenient type alias for an [`AccountSnapshot`] keyed with [`ExchangeId`],
-/// [`AssetNameExchange`], and [`InstrumentNameExchange`].
-pub type UnindexedAccountSnapshot =
-    AccountSnapshot<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
+/// Convenient type alias for an [`AccountSnapshot`] keyed with [`ExchangeId`]
+/// and [`AssetNameExchange`].
+pub type UnindexedAccountSnapshot = AccountSnapshot<ExchangeId, AssetNameExchange>;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct AccountEvent<
@@ -83,7 +82,7 @@ impl<ExchangeKey, AssetKey, InstrumentKey> AccountEvent<ExchangeKey, AssetKey, I
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, From)]
 pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     /// Full [`AccountSnapshot`] - replaces all existing state.
-    Snapshot(AccountSnapshot<ExchangeKey, AssetKey, InstrumentKey>),
+    Snapshot(AccountSnapshot<ExchangeKey, AssetKey>),
 
     /// Single [`AssetBalance`] snapshot - replaces existing balance state.
     BalanceSnapshot(Snapshot<AssetBalance<AssetKey>>),
@@ -105,7 +104,7 @@ where
     AssetKey: Eq,
     InstrumentKey: Eq,
 {
-    pub fn snapshot(self) -> Option<AccountSnapshot<ExchangeKey, AssetKey, InstrumentKey>> {
+    pub fn snapshot(self) -> Option<AccountSnapshot<ExchangeKey, AssetKey>> {
         match self.kind {
             AccountEventKind::Snapshot(snapshot) => Some(snapshot),
             _ => None,
@@ -116,47 +115,20 @@ where
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Constructor,
 )]
-pub struct AccountSnapshot<
-    ExchangeKey = ExchangeIndex,
-    AssetKey = AssetIndex,
-    InstrumentKey = InstrumentIndex,
-> {
+pub struct AccountSnapshot<ExchangeKey = ExchangeIndex, AssetKey = AssetIndex> {
     pub exchange: ExchangeKey,
     pub balances: Vec<AssetBalance<AssetKey>>,
-    pub instruments: Vec<InstrumentAccountSnapshot<ExchangeKey, AssetKey, InstrumentKey>>,
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Constructor,
-)]
-pub struct InstrumentAccountSnapshot<
-    ExchangeKey = ExchangeIndex,
-    AssetKey = AssetIndex,
-    InstrumentKey = InstrumentIndex,
-> {
-    pub instrument: InstrumentKey,
-    #[serde(default = "Vec::new")]
-    pub orders: Vec<OrderSnapshot<ExchangeKey, AssetKey, InstrumentKey>>,
-}
-
-impl<ExchangeKey, AssetKey, InstrumentKey> AccountSnapshot<ExchangeKey, AssetKey, InstrumentKey> {
+impl<ExchangeKey, AssetKey> AccountSnapshot<ExchangeKey, AssetKey> {
     pub fn time_most_recent(&self) -> Option<DateTime<Utc>> {
-        let order_times = self.instruments.iter().flat_map(|instrument| {
-            instrument
-                .orders
-                .iter()
-                .filter_map(|order| order.state.time_exchange())
-        });
-        let balance_times = self.balances.iter().map(|balance| balance.time_exchange);
-
-        order_times.chain(balance_times).max()
+        self.balances
+            .iter()
+            .map(|balance| balance.time_exchange)
+            .max()
     }
 
     pub fn assets(&self) -> impl Iterator<Item = &AssetKey> {
         self.balances.iter().map(|balance| &balance.asset)
-    }
-
-    pub fn instruments(&self) -> impl Iterator<Item = &InstrumentKey> {
-        self.instruments.iter().map(|snapshot| &snapshot.instrument)
     }
 }

--- a/barter-execution/src/order/mod.rs
+++ b/barter-execution/src/order/mod.rs
@@ -49,10 +49,25 @@ pub type OrderSnapshot<
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
-
 pub struct OrderEvent<State, ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
     pub key: OrderKey<ExchangeKey, InstrumentKey>,
     pub state: State,
+}
+
+impl<'a, State: Clone, ExchangeKey: Copy>
+    OrderEvent<State, ExchangeKey, &'a InstrumentNameExchange>
+{
+    pub fn cloned_instrument(self) -> OrderEvent<State, ExchangeKey, InstrumentNameExchange> {
+        OrderEvent {
+            key: OrderKey {
+                exchange: self.key.exchange,
+                instrument: self.key.instrument.clone(),
+                strategy: self.key.strategy,
+                cid: self.key.cid,
+            },
+            state: self.state,
+        }
+    }
 }
 
 #[derive(

--- a/barter-execution/src/order/mod.rs
+++ b/barter-execution/src/order/mod.rs
@@ -1,11 +1,11 @@
 use crate::order::{
     id::StrategyId,
     request::{OrderRequestCancel, OrderRequestOpen, RequestCancel, RequestOpen},
-    state::UnindexedOrderState,
+    state::{OrderState, UnindexedOrderState},
 };
 use barter_instrument::{
     Side,
-    asset::{AssetIndex, name::AssetNameExchange},
+    asset::AssetIndex,
     exchange::{ExchangeId, ExchangeIndex},
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
 };
@@ -13,7 +13,7 @@ use derive_more::{Constructor, Display};
 use id::ClientOrderId;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use state::{ActiveOrderState, Cancelled, InactiveOrderState, Open, OpenInFlight, OrderState};
+use state::OpenInFlight;
 
 /// `Order` related identifiers.
 pub mod id;
@@ -37,11 +37,7 @@ pub type UnindexedOrderKey = OrderKey<ExchangeId, InstrumentNameExchange>;
 
 /// Convenient type alias for an [`OrderSnapshot`] keyed with [`ExchangeId`], [`AssetNameExchange`],
 /// and [`InstrumentNameExchange`].
-pub type UnindexedOrderSnapshot = Order<
-    ExchangeId,
-    InstrumentNameExchange,
-    OrderState<AssetNameExchange, InstrumentNameExchange>,
->;
+pub type UnindexedOrderSnapshot = Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>;
 
 /// Convenient type alias for an [`Order`] [`OrderState`] snapshot.
 pub type OrderSnapshot<
@@ -82,54 +78,7 @@ pub struct Order<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex, S
     pub state: State,
 }
 
-impl<ExchangeKey, AssetKey, InstrumentKey>
-    Order<ExchangeKey, InstrumentKey, OrderState<AssetKey, InstrumentKey>>
-{
-    pub fn to_active(&self) -> Option<Order<ExchangeKey, InstrumentKey, ActiveOrderState>>
-    where
-        ExchangeKey: Clone,
-        InstrumentKey: Clone,
-    {
-        let OrderState::Active(state) = &self.state else {
-            return None;
-        };
-
-        Some(Order {
-            key: self.key.clone(),
-            side: self.side,
-            price: self.price,
-            quantity: self.quantity,
-            kind: self.kind,
-            time_in_force: self.time_in_force,
-            state: state.clone(),
-        })
-    }
-
-    pub fn to_inactive(
-        &self,
-    ) -> Option<Order<ExchangeKey, InstrumentKey, InactiveOrderState<AssetKey, InstrumentKey>>>
-    where
-        ExchangeKey: Clone,
-        AssetKey: Clone,
-        InstrumentKey: Clone,
-    {
-        let OrderState::Inactive(state) = &self.state else {
-            return None;
-        };
-
-        Some(Order {
-            key: self.key.clone(),
-            side: self.side,
-            price: self.price,
-            quantity: self.quantity,
-            kind: self.kind,
-            time_in_force: self.time_in_force,
-            state: state.clone(),
-        })
-    }
-}
-
-impl<ExchangeKey, InstrumentKey> Order<ExchangeKey, InstrumentKey, ActiveOrderState>
+impl<ExchangeKey, InstrumentKey> Order<ExchangeKey, InstrumentKey, OrderState>
 where
     ExchangeKey: Clone,
     InstrumentKey: Clone,
@@ -138,9 +87,12 @@ where
         let Order { key, state, .. } = self;
 
         let request_cancel = match state {
-            ActiveOrderState::OpenInFlight(_) => RequestCancel { id: None },
-            ActiveOrderState::Open(open) => RequestCancel {
+            OrderState::OpenInFlight(_) => RequestCancel { id: None },
+            OrderState::Open(open) => RequestCancel {
                 id: Some(open.id.clone()),
+            },
+            OrderState::CancelInFlight(cancel_in_flight) => RequestCancel {
+                id: cancel_in_flight.order.as_ref().map(|o| o.id.clone()),
             },
             _ => return None,
         };
@@ -170,8 +122,22 @@ pub enum TimeInForce {
     ImmediateOrCancel,
 }
 
+impl<ExchangeKey, InstrumentKey, State> Order<ExchangeKey, InstrumentKey, State> {
+    pub fn map_state<S>(self, f: impl FnOnce(State) -> S) -> Order<ExchangeKey, InstrumentKey, S> {
+        Order {
+            key: self.key,
+            side: self.side,
+            price: self.price,
+            quantity: self.quantity,
+            kind: self.kind,
+            time_in_force: self.time_in_force,
+            state: f(self.state),
+        }
+    }
+}
+
 impl<ExchangeKey, InstrumentKey> From<&OrderRequestOpen<ExchangeKey, InstrumentKey>>
-    for Order<ExchangeKey, InstrumentKey, ActiveOrderState>
+    for Order<ExchangeKey, InstrumentKey, OrderState>
 where
     ExchangeKey: Clone,
     InstrumentKey: Clone,
@@ -196,85 +162,7 @@ where
             quantity: *quantity,
             kind: *kind,
             time_in_force: *time_in_force,
-            state: ActiveOrderState::OpenInFlight(OpenInFlight),
-        }
-    }
-}
-
-impl<ExchangeKey, InstrumentKey> From<Order<ExchangeKey, InstrumentKey, Open>>
-    for Order<ExchangeKey, InstrumentKey, ActiveOrderState>
-{
-    fn from(value: Order<ExchangeKey, InstrumentKey, Open>) -> Self {
-        let Order {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state,
-        } = value;
-
-        Self {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state: ActiveOrderState::Open(state),
-        }
-    }
-}
-
-impl<ExchangeKey, AssetKey, InstrumentKey> From<Order<ExchangeKey, InstrumentKey, Open>>
-    for Order<ExchangeKey, InstrumentKey, OrderState<AssetKey, InstrumentKey>>
-{
-    fn from(value: Order<ExchangeKey, InstrumentKey, Open>) -> Self {
-        let Order {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state,
-        } = value;
-
-        Self {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state: OrderState::Active(ActiveOrderState::Open(state)),
-        }
-    }
-}
-
-impl<ExchangeKey, AssetKey, InstrumentKey> From<Order<ExchangeKey, InstrumentKey, Cancelled>>
-    for Order<ExchangeKey, InstrumentKey, OrderState<AssetKey, InstrumentKey>>
-{
-    fn from(value: Order<ExchangeKey, InstrumentKey, Cancelled>) -> Self {
-        let Order {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state,
-        } = value;
-
-        Self {
-            key,
-            side,
-            price,
-            quantity,
-            kind,
-            time_in_force,
-            state: OrderState::Inactive(InactiveOrderState::Cancelled(state)),
+            state: OrderState::OpenInFlight(OpenInFlight),
         }
     }
 }

--- a/barter-execution/src/order/request.rs
+++ b/barter-execution/src/order/request.rs
@@ -1,6 +1,10 @@
 use crate::{
     error::OrderError,
-    order::{OrderEvent, OrderKind, TimeInForce, id::OrderId, state::Cancelled},
+    order::{
+        Order, OrderEvent, OrderKind, TimeInForce,
+        id::OrderId,
+        state::{Cancelled, Open},
+    },
 };
 use barter_instrument::{
     Side,
@@ -12,11 +16,27 @@ use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
+pub type OrderRequestInfo<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
+    OrderEvent<RequestInfo, ExchangeKey, InstrumentKey>;
+
 pub type OrderRequestOpen<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
     OrderEvent<RequestOpen, ExchangeKey, InstrumentKey>;
 
 pub type OrderRequestCancel<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
     OrderEvent<RequestCancel, ExchangeKey, InstrumentKey>;
+
+pub type OrderResponseInfo<
+    ExchangeKey = ExchangeIndex,
+    AssetKey = AssetIndex,
+    InstrumentKey = InstrumentIndex,
+> = OrderEvent<
+    Result<Order<ExchangeId, InstrumentNameExchange, Open>, OrderError<AssetKey, InstrumentKey>>,
+    ExchangeKey,
+    InstrumentKey,
+>;
+
+pub type UnindexedOrderResponseInfo =
+    OrderResponseInfo<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
 
 pub type OrderResponseCancel<
     ExchangeKey = ExchangeIndex,
@@ -26,6 +46,13 @@ pub type OrderResponseCancel<
 
 pub type UnindexedOrderResponseCancel =
     OrderResponseCancel<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
+)]
+pub struct RequestInfo {
+    pub id: Option<OrderId>,
+}
 
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,

--- a/barter-execution/src/order/request.rs
+++ b/barter-execution/src/order/request.rs
@@ -1,10 +1,6 @@
 use crate::{
     error::OrderError,
-    order::{
-        Order, OrderEvent, OrderKind, TimeInForce,
-        id::OrderId,
-        state::{Cancelled, Open},
-    },
+    order::{OrderEvent, OrderKind, TimeInForce, id::OrderId, state::Cancelled},
 };
 use barter_instrument::{
     Side,
@@ -16,27 +12,14 @@ use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-pub type OrderRequestInfo<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
-    OrderEvent<RequestInfo, ExchangeKey, InstrumentKey>;
+pub type OrderRequestSnapshot<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
+    OrderEvent<RequestSnapshot, ExchangeKey, InstrumentKey>;
 
 pub type OrderRequestOpen<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
     OrderEvent<RequestOpen, ExchangeKey, InstrumentKey>;
 
 pub type OrderRequestCancel<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> =
     OrderEvent<RequestCancel, ExchangeKey, InstrumentKey>;
-
-pub type OrderResponseInfo<
-    ExchangeKey = ExchangeIndex,
-    AssetKey = AssetIndex,
-    InstrumentKey = InstrumentIndex,
-> = OrderEvent<
-    Result<Order<ExchangeId, InstrumentNameExchange, Open>, OrderError<AssetKey, InstrumentKey>>,
-    ExchangeKey,
-    InstrumentKey,
->;
-
-pub type UnindexedOrderResponseInfo =
-    OrderResponseInfo<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
 
 pub type OrderResponseCancel<
     ExchangeKey = ExchangeIndex,
@@ -47,11 +30,13 @@ pub type OrderResponseCancel<
 pub type UnindexedOrderResponseCancel =
     OrderResponseCancel<ExchangeId, AssetNameExchange, InstrumentNameExchange>;
 
+pub type UnindexedOrderRequestSnapshot = OrderRequestSnapshot<ExchangeId, InstrumentNameExchange>;
+
 #[derive(
-    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
-pub struct RequestInfo {
-    pub id: Option<OrderId>,
+pub struct RequestSnapshot {
+    pub id: OrderId,
 }
 
 #[derive(

--- a/barter-execution/src/order/state.rs
+++ b/barter-execution/src/order/state.rs
@@ -4,7 +4,7 @@ use barter_instrument::{
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
 };
 use chrono::{DateTime, Utc};
-use derive_more::{Constructor, From};
+use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -12,65 +12,31 @@ use serde::{Deserialize, Serialize};
 /// and [`InstrumentNameExchange`].
 pub type UnindexedOrderState = OrderState<AssetNameExchange, InstrumentNameExchange>;
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub enum OrderState<AssetKey = AssetIndex, InstrumentKey = InstrumentIndex> {
-    Active(ActiveOrderState),
-    Inactive(InactiveOrderState<AssetKey, InstrumentKey>),
-}
-
-impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
-    pub fn active<S>(state: S) -> Self
-    where
-        S: Into<ActiveOrderState>,
-    {
-        OrderState::Active(state.into())
-    }
-
-    pub fn inactive<S>(state: S) -> Self
-    where
-        S: Into<InactiveOrderState<AssetKey, InstrumentKey>>,
-    {
-        OrderState::Inactive(state.into())
-    }
-
-    pub fn fully_filled() -> Self {
-        Self::Inactive(InactiveOrderState::FullyFilled)
-    }
-
-    pub fn expired() -> Self {
-        Self::Inactive(InactiveOrderState::Expired)
-    }
-
-    pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
-        match self {
-            Self::Active(active) => match active {
-                ActiveOrderState::OpenInFlight(_) => None,
-                ActiveOrderState::Open(state) => Some(state.time_exchange),
-                ActiveOrderState::CancelInFlight(state) => {
-                    state.order.as_ref().map(|order| order.time_exchange)
-                }
-            },
-            Self::Inactive(inactive) => match inactive {
-                InactiveOrderState::Cancelled(state) => Some(state.time_exchange),
-                _ => None,
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
-pub enum ActiveOrderState {
     OpenInFlight(OpenInFlight),
     Open(Open),
     CancelInFlight(CancelInFlight),
+    Cancelled(Cancelled),
+    FullyFilled(FullyFilled),
+    OpenFailed(OrderError<AssetKey, InstrumentKey>),
+    Expired(Expired),
 }
 
-impl ActiveOrderState {
+impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
+    pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
+        match self {
+            OrderState::Open(open) => Some(open.time_exchange),
+            OrderState::Cancelled(cancelled) => Some(cancelled.time_exchange),
+            _ => None,
+        }
+    }
+
     pub fn open_meta(&self) -> Option<&Open> {
         match self {
-            Self::OpenInFlight(_) => None,
-            Self::Open(open) => Some(open),
-            Self::CancelInFlight(cancel) => cancel.order.as_ref(),
+            OrderState::Open(open) => Some(open),
+            OrderState::CancelInFlight(cancel) => cancel.order.as_ref(),
+            _ => None,
         }
     }
 }
@@ -100,14 +66,6 @@ pub struct CancelInFlight {
     pub order: Option<Open>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
-pub enum InactiveOrderState<AssetKey, InstrumentKey> {
-    Cancelled(Cancelled),
-    FullyFilled,
-    OpenFailed(OrderError<AssetKey, InstrumentKey>),
-    Expired,
-}
-
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
@@ -115,3 +73,9 @@ pub struct Cancelled {
     pub id: OrderId,
     pub time_exchange: DateTime<Utc>,
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+pub struct FullyFilled;
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+pub struct Expired;

--- a/barter-execution/src/order/state.rs
+++ b/barter-execution/src/order/state.rs
@@ -24,6 +24,18 @@ pub enum OrderState<AssetKey = AssetIndex, InstrumentKey = InstrumentIndex> {
 }
 
 impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
+    pub fn order_id(&self) -> Option<&OrderId> {
+        match self {
+            OrderState::Open(open) => Some(&open.id),
+            OrderState::CancelInFlight(cancel) => cancel.order.as_ref().map(|o| &o.id),
+            OrderState::Cancelled(cancelled) => Some(&cancelled.id),
+            OrderState::OpenInFlight(_)
+            | OrderState::FullyFilled(_)
+            | OrderState::OpenFailed(_)
+            | OrderState::Expired(_) => None,
+        }
+    }
+
     pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
         match self {
             OrderState::Open(open) => Some(open.time_exchange),
@@ -37,6 +49,18 @@ impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
             OrderState::Open(open) => Some(open),
             OrderState::CancelInFlight(cancel) => cancel.order.as_ref(),
             _ => None,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        match self {
+            OrderState::OpenInFlight(_) | OrderState::Open(_) | OrderState::CancelInFlight(_) => {
+                true
+            }
+            OrderState::Cancelled(_)
+            | OrderState::FullyFilled(_)
+            | OrderState::OpenFailed(_)
+            | OrderState::Expired(_) => false,
         }
     }
 }

--- a/barter/benches/backtest/mod.rs
+++ b/barter/benches/backtest/mod.rs
@@ -106,20 +106,6 @@ const CONFIG: &str = r#"
               },
               "time_exchange": "2025-03-24T21:30:00Z"
             }
-          ],
-          "instruments": [
-            {
-              "instrument": "BTCUSDT",
-              "orders": []
-            },
-            {
-              "instrument": "ETHUSDT",
-              "orders": []
-            },
-            {
-              "instrument": "SOLUSDT",
-              "orders": []
-            }
           ]
         }
       }

--- a/barter/src/engine/mod.rs
+++ b/barter/src/engine/mod.rs
@@ -13,8 +13,10 @@ use crate::{
         command::Command,
         execution_tx::ExecutionTxMap,
         state::{
-            EngineState, instrument::data::InstrumentDataState,
-            order::in_flight_recorder::InFlightRequestRecorder, position::PositionExited,
+            EngineState,
+            instrument::data::InstrumentDataState,
+            order::{in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
+            position::PositionExited,
             trading::TradingState,
         },
     },
@@ -28,14 +30,17 @@ use crate::{
     },
 };
 use barter_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
-use barter_execution::AccountEvent;
+use barter_execution::{
+    AccountEvent, AccountEventKind,
+    order::request::{OrderRequestSnapshot, RequestSnapshot},
+};
 use barter_instrument::{asset::QuoteAsset, exchange::ExchangeIndex, instrument::InstrumentIndex};
 use barter_integration::channel::Tx;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Defines how the [`Engine`] actions a [`Command`], and the associated outputs.
 pub mod action;
@@ -268,6 +273,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         InstrumentData: for<'a> Processor<&'a AccountEvent>,
         GlobalData: for<'a> Processor<&'a AccountEvent>,
         Strategy: OnDisconnectStrategy<Clock, EngineState<GlobalData, InstrumentData>, ExecutionTxs, Risk>,
+        ExecutionTxs: ExecutionTxMap<ExchangeIndex, InstrumentIndex>,
     {
         match event {
             AccountStreamEvent::Reconnecting(exchange) => {
@@ -277,12 +283,70 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
                 UpdateFromAccountOutput::OnDisconnect(Strategy::on_disconnect(self, *exchange))
             }
-            AccountStreamEvent::Item(event) => self
-                .state
-                .update_from_account(event)
-                .map(UpdateFromAccountOutput::PositionExit)
-                .unwrap_or(UpdateFromAccountOutput::None),
+            AccountStreamEvent::Item(account_event) => {
+                // TODO: This is here temporarily. The ExecutionManager currently
+                // doesn't know which orders it is managing on the exchange. This is going
+                // to change when the ExecutionManager will hold actual order states.
+                let snapshot_requests =
+                    self.order_snapshot_requests_on_account_snapshot(account_event);
+
+                let result = self
+                    .state
+                    .update_from_account(account_event)
+                    .map(UpdateFromAccountOutput::PositionExit)
+                    .unwrap_or(UpdateFromAccountOutput::None);
+
+                if let Some(exchange) = snapshot_requests.first().map(|r| r.key.exchange) {
+                    match self.execution_txs.find(&exchange) {
+                        Ok(tx) => {
+                            if tx
+                                .send(ExecutionRequest::Snapshots(snapshot_requests))
+                                .is_err()
+                            {
+                                warn!(
+                                    "ExecutionManager channel closed while sending ExecutionRequest::Snapshots"
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            warn!(
+                                ?error,
+                                "Failed to find ExecutionTx for order snapshot requests"
+                            );
+                        }
+                    }
+                }
+
+                result
+            }
         }
+    }
+
+    /// Returns [`OrderRequestSnapshot`]s for all active orders tracked by the engine for the
+    /// snapshot's exchange, so the engine can reconcile their states.
+    fn order_snapshot_requests_on_account_snapshot(
+        &self,
+        event: &AccountEvent,
+    ) -> Vec<OrderRequestSnapshot<ExchangeIndex, InstrumentIndex>> {
+        if !matches!(event.kind, AccountEventKind::Snapshot(_)) {
+            return vec![];
+        }
+
+        self.state
+            .instruments
+            .0
+            .values()
+            .filter(|ins_state| ins_state.instrument.exchange == event.exchange)
+            .flat_map(|ins_state| ins_state.orders.orders())
+            .filter(|order| order.state.is_active())
+            .flat_map(|order| {
+                let order_id = order.state.order_id()?.clone();
+                Some(OrderRequestSnapshot {
+                    key: order.key.clone(),
+                    state: RequestSnapshot { id: order_id },
+                })
+            })
+            .collect()
     }
 
     /// Update the [`Engine`] from a [`MarketStreamEvent`].

--- a/barter/src/engine/state/instrument/mod.rs
+++ b/barter/src/engine/state/instrument/mod.rs
@@ -8,19 +8,15 @@ use crate::{
 };
 use barter_data::event::MarketEvent;
 use barter_execution::{
-    InstrumentAccountSnapshot,
-    order::{Order, OrderKey, request::OrderResponseCancel, state::OrderState},
+    order::{Order, request::OrderResponseCancel, state::OrderState},
     trade::Trade,
 };
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, QuoteAsset},
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
-    instrument::{
-        Instrument, InstrumentIndex,
-        name::{InstrumentNameExchange, InstrumentNameInternal},
-    },
+    instrument::{Instrument, InstrumentIndex, name::InstrumentNameInternal},
 };
 use barter_integration::collection::{FnvIndexMap, snapshot::Snapshot};
 use chrono::{DateTime, Utc};
@@ -269,23 +265,6 @@ pub struct InstrumentState<
 impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     InstrumentState<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
 {
-    /// Updates the instrument state using an account snapshot from the exchange.
-    ///
-    /// This updates active orders for the instrument, using timestamps where relevant to ensure
-    /// the most recent order state is applied.
-    pub fn update_from_account_snapshot(
-        &mut self,
-        snapshot: &InstrumentAccountSnapshot<ExchangeKey, AssetKey, InstrumentKey>,
-    ) where
-        ExchangeKey: Debug + Clone,
-        InstrumentKey: Debug + Clone,
-        AssetKey: Debug + Clone,
-    {
-        for order in &snapshot.orders {
-            self.update_from_order_snapshot(Snapshot(order))
-        }
-    }
-
     /// Updates the instrument state from an [`Order`] snapshot.
     pub fn update_from_order_snapshot(
         &mut self,
@@ -350,65 +329,6 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
         };
 
         position.update_pnl_unrealised(price);
-    }
-}
-
-pub fn generate_unindexed_instrument_account_snapshot<
-    InstrumentData,
-    ExchangeKey,
-    AssetKey,
-    InstrumentKey,
->(
-    exchange: ExchangeId,
-    state: &InstrumentState<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>,
-) -> InstrumentAccountSnapshot<ExchangeId, AssetNameExchange, InstrumentNameExchange>
-where
-    ExchangeKey: Debug + Clone,
-    InstrumentKey: Debug + Clone,
-{
-    let InstrumentState {
-        key: _,
-        instrument,
-        tear_sheet: _,
-        position: _,
-        orders,
-        data: _,
-    } = state;
-
-    InstrumentAccountSnapshot {
-        instrument: instrument.name_exchange.clone(),
-        orders: orders
-            .orders()
-            .filter_map(|order| {
-                let Order {
-                    key,
-                    side,
-                    price,
-                    quantity,
-                    kind,
-                    time_in_force,
-                    state: OrderState::Open(open),
-                } = order
-                else {
-                    return None;
-                };
-
-                Some(Order {
-                    key: OrderKey {
-                        exchange,
-                        instrument: instrument.name_exchange.clone(),
-                        strategy: key.strategy.clone(),
-                        cid: key.cid.clone(),
-                    },
-                    side: *side,
-                    price: *price,
-                    quantity: *quantity,
-                    kind: *kind,
-                    time_in_force: *time_in_force,
-                    state: OrderState::Open(open.clone()),
-                })
-            })
-            .collect(),
     }
 }
 

--- a/barter/src/engine/state/instrument/mod.rs
+++ b/barter/src/engine/state/instrument/mod.rs
@@ -9,11 +9,7 @@ use crate::{
 use barter_data::event::MarketEvent;
 use barter_execution::{
     InstrumentAccountSnapshot,
-    order::{
-        Order, OrderKey,
-        request::OrderResponseCancel,
-        state::{ActiveOrderState, OrderState},
-    },
+    order::{Order, OrderKey, request::OrderResponseCancel, state::OrderState},
     trade::Trade,
 };
 use barter_instrument::{
@@ -391,7 +387,7 @@ where
                     quantity,
                     kind,
                     time_in_force,
-                    state: ActiveOrderState::Open(open),
+                    state: OrderState::Open(open),
                 } = order
                 else {
                     return None;
@@ -409,7 +405,7 @@ where
                     quantity: *quantity,
                     kind: *kind,
                     time_in_force: *time_in_force,
-                    state: OrderState::active(open.clone()),
+                    state: OrderState::Open(open.clone()),
                 })
             })
             .collect(),

--- a/barter/src/engine/state/mod.rs
+++ b/barter/src/engine/state/mod.rs
@@ -10,7 +10,9 @@ use crate::engine::{
     },
 };
 use barter_data::event::MarketEvent;
-use barter_execution::{AccountEvent, AccountEventKind, UnindexedAccountSnapshot, balance::AssetBalance};
+use barter_execution::{
+    AccountEvent, AccountEventKind, UnindexedAccountSnapshot, balance::AssetBalance,
+};
 use barter_instrument::{
     Keyed,
     asset::{AssetIndex, QuoteAsset},
@@ -19,8 +21,8 @@ use barter_instrument::{
     instrument::{Instrument, InstrumentIndex},
 };
 use barter_integration::collection::{one_or_many::OneOrMany, snapshot::Snapshot};
-use fnv::FnvHashMap;
 use derive_more::Constructor;
+use fnv::FnvHashMap;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 

--- a/barter/src/engine/state/mod.rs
+++ b/barter/src/engine/state/mod.rs
@@ -4,18 +4,13 @@ use crate::engine::{
         asset::{AssetStates, filter::AssetFilter},
         builder::EngineStateBuilder,
         connectivity::ConnectivityStates,
-        instrument::{
-            InstrumentStates, data::InstrumentDataState, filter::InstrumentFilter,
-            generate_unindexed_instrument_account_snapshot,
-        },
+        instrument::{InstrumentStates, data::InstrumentDataState},
         position::PositionExited,
         trading::TradingState,
     },
 };
 use barter_data::event::MarketEvent;
-use barter_execution::{
-    AccountEvent, AccountEventKind, UnindexedAccountSnapshot, balance::AssetBalance,
-};
+use barter_execution::{AccountEvent, AccountEventKind, UnindexedAccountSnapshot, balance::AssetBalance};
 use barter_instrument::{
     Keyed,
     asset::{AssetIndex, QuoteAsset},
@@ -24,8 +19,8 @@ use barter_instrument::{
     instrument::{Instrument, InstrumentIndex},
 };
 use barter_integration::collection::{one_or_many::OneOrMany, snapshot::Snapshot};
-use derive_more::Constructor;
 use fnv::FnvHashMap;
+use derive_more::Constructor;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -119,14 +114,6 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
                         .asset_index_mut(&balance.asset)
                         .update_from_balance(Snapshot(balance))
                 }
-                for instrument in &snapshot.instruments {
-                    let instrument_state = self
-                        .instruments
-                        .instrument_index_mut(&instrument.instrument);
-
-                    instrument_state.update_from_account_snapshot(instrument);
-                    instrument_state.data.process(event);
-                }
                 None
             }
             AccountEventKind::BalanceSnapshot(balance) => {
@@ -201,15 +188,13 @@ impl<GlobalData, InstrumentData> From<&EngineState<GlobalData, InstrumentData>>
             global: _,
             connectivity,
             assets,
-            instruments,
+            instruments: _,
         } = value;
 
-        // Allocate appropriately
         let mut snapshots =
             FnvHashMap::with_capacity_and_hasher(connectivity.exchanges.len(), Default::default());
 
-        // Insert UnindexedAccountSnapshot for each exchange
-        for (index, exchange) in connectivity.exchange_ids().enumerate() {
+        for exchange in connectivity.exchange_ids() {
             snapshots.insert(
                 *exchange,
                 UnindexedAccountSnapshot {
@@ -218,14 +203,6 @@ impl<GlobalData, InstrumentData> From<&EngineState<GlobalData, InstrumentData>>
                         .filtered(&AssetFilter::Exchanges(OneOrMany::One(*exchange)))
                         .map(AssetBalance::from)
                         .collect(),
-                    instruments: instruments
-                        .instruments(&InstrumentFilter::Exchanges(OneOrMany::One(ExchangeIndex(
-                            index,
-                        ))))
-                        .map(|snapshot| {
-                            generate_unindexed_instrument_account_snapshot(*exchange, snapshot)
-                        })
-                        .collect::<Vec<_>>(),
                 },
             );
         }

--- a/barter/src/engine/state/order/manager.rs
+++ b/barter/src/engine/state/order/manager.rs
@@ -1,9 +1,5 @@
 use crate::engine::state::order::in_flight_recorder::InFlightRequestRecorder;
-use barter_execution::order::{
-    Order,
-    request::OrderResponseCancel,
-    state::{ActiveOrderState, OrderState},
-};
+use barter_execution::order::{Order, request::OrderResponseCancel, state::OrderState};
 use barter_integration::collection::snapshot::Snapshot;
 use std::fmt::Debug;
 
@@ -16,7 +12,7 @@ where
 {
     fn orders<'a>(
         &'a self,
-    ) -> impl Iterator<Item = &'a Order<ExchangeKey, InstrumentKey, ActiveOrderState>>
+    ) -> impl Iterator<Item = &'a Order<ExchangeKey, InstrumentKey, OrderState>>
     where
         ExchangeKey: 'a,
         InstrumentKey: 'a;

--- a/barter/src/engine/state/order/mod.rs
+++ b/barter/src/engine/state/order/mod.rs
@@ -5,7 +5,7 @@ use barter_execution::order::{
     Order,
     id::ClientOrderId,
     request::{OrderRequestCancel, OrderRequestOpen, OrderResponseCancel},
-    state::{ActiveOrderState, CancelInFlight, OrderState},
+    state::{CancelInFlight, OrderState},
 };
 use barter_instrument::{exchange::ExchangeIndex, instrument::InstrumentIndex};
 use barter_integration::collection::snapshot::Snapshot;
@@ -37,7 +37,7 @@ pub mod manager;
 /// 4. Cancelled/Expired/FullyFilled - Terminal states, once achieved order is no longer tracked.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Constructor)]
 pub struct Orders<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex>(
-    pub FnvHashMap<ClientOrderId, Order<ExchangeKey, InstrumentKey, ActiveOrderState>>,
+    pub FnvHashMap<ClientOrderId, Order<ExchangeKey, InstrumentKey, OrderState>>,
 );
 
 impl<ExchangeKey, InstrumentKey> Default for Orders<ExchangeKey, InstrumentKey> {
@@ -54,7 +54,7 @@ where
 {
     fn orders<'a>(
         &'a self,
-    ) -> impl Iterator<Item = &'a Order<ExchangeKey, InstrumentKey, ActiveOrderState>>
+    ) -> impl Iterator<Item = &'a Order<ExchangeKey, InstrumentKey, OrderState>>
     where
         ExchangeKey: 'a,
         InstrumentKey: 'a,
@@ -70,27 +70,58 @@ where
     {
         let Snapshot(snapshot) = snapshot;
 
-        let (mut current_entry, update) = match (
-            self.0.entry(snapshot.key.cid.clone()),
-            snapshot.to_active(),
-        ) {
-            // Order untracked, input Snapshot is InactiveOrderState (ie/ finished), so ignore
-            (Entry::Vacant(_), None) => {
-                warn!(
-                    exchange = ?snapshot.key.exchange,
-                    instrument = ?snapshot.key.instrument,
-                    strategy = %snapshot.key.strategy,
-                    cid = %snapshot.key.cid,
-                    update = ?snapshot,
-                    "OrderManager received inactive order snapshot for untracked order - ignoring"
-                );
+        // Resolve active state from the snapshot, handling inactive states immediately.
+        // Active variants (OpenInFlight, Open, CancelInFlight) carry no AssetKey/InstrumentKey
+        // data so they convert to OrderState (default params) without loss.
+        let active_state: OrderState = match &snapshot.state {
+            OrderState::Cancelled(_)
+            | OrderState::FullyFilled(_)
+            | OrderState::OpenFailed(_)
+            | OrderState::Expired(_) => {
+                match self.0.entry(snapshot.key.cid.clone()) {
+                    Entry::Vacant(_) => {
+                        warn!(
+                            exchange = ?snapshot.key.exchange,
+                            instrument = ?snapshot.key.instrument,
+                            strategy = %snapshot.key.strategy,
+                            cid = %snapshot.key.cid,
+                            update = ?snapshot,
+                            "OrderManager received inactive order snapshot for untracked order - ignoring"
+                        );
+                    }
+                    Entry::Occupied(entry) => {
+                        debug!(
+                            exchange = ?snapshot.key.exchange,
+                            instrument = ?snapshot.key.instrument,
+                            strategy = %snapshot.key.strategy,
+                            cid = %snapshot.key.cid,
+                            update = ?snapshot,
+                            "OrderManager received inactive order snapshot for tracked order - removing"
+                        );
+                        entry.remove();
+                    }
+                }
                 return;
             }
+            OrderState::OpenInFlight(s) => OrderState::OpenInFlight(*s),
+            OrderState::Open(s) => OrderState::Open(s.clone()),
+            OrderState::CancelInFlight(s) => OrderState::CancelInFlight(s.clone()),
+        };
 
-            // Order untracked, input Snapshot is ActiveOrderState, so insert
-            (Entry::Vacant(entry), Some(update)) => {
+        let update = Order {
+            key: snapshot.key.clone(),
+            side: snapshot.side,
+            price: snapshot.price,
+            quantity: snapshot.quantity,
+            kind: snapshot.kind,
+            time_in_force: snapshot.time_in_force,
+            state: active_state,
+        };
+
+        let mut current_entry = match self.0.entry(snapshot.key.cid.clone()) {
+            Entry::Vacant(entry) => {
                 match &update.state {
-                    ActiveOrderState::Open(open)
+                    OrderState::Open(open)
                         if open.quantity_remaining(update.quantity).is_zero() =>
                     {
                         debug!(
@@ -116,27 +147,11 @@ where
                 }
                 return;
             }
-
-            // Order tracked, input Snapshot is InactiveOrderState (ie/ finished), so remove
-            (Entry::Occupied(entry), None) => {
-                debug!(
-                    exchange = ?snapshot.key.exchange,
-                    instrument = ?snapshot.key.instrument,
-                    strategy = %snapshot.key.strategy,
-                    cid = %snapshot.key.cid,
-                    update = ?snapshot,
-                    "OrderManager received inactive order snapshot for tracked order - removing"
-                );
-                entry.remove();
-                return;
-            }
-
-            // Order tracked, input Snapshot is ActiveOrderState, so forward for further processing
-            (Entry::Occupied(entry), Some(update)) => (entry, update),
+            Entry::Occupied(entry) => entry,
         };
 
         match (&current_entry.get().state, update.state) {
-            (ActiveOrderState::OpenInFlight(_), ActiveOrderState::OpenInFlight(_)) => {
+            (OrderState::OpenInFlight(_), OrderState::OpenInFlight(_)) => {
                 warn!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -146,7 +161,7 @@ where
                     "OrderManager received a duplicate OpenInFlight recording - ignoring"
                 );
             }
-            (ActiveOrderState::OpenInFlight(_), ActiveOrderState::Open(open)) => {
+            (OrderState::OpenInFlight(_), OrderState::Open(open)) => {
                 debug!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -158,10 +173,10 @@ where
                 if open.quantity_remaining(update.quantity).is_zero() {
                     current_entry.remove();
                 } else {
-                    current_entry.get_mut().state = ActiveOrderState::Open(open);
+                    current_entry.get_mut().state = OrderState::Open(open);
                 }
             }
-            (ActiveOrderState::OpenInFlight(_), ActiveOrderState::CancelInFlight(update)) => {
+            (OrderState::OpenInFlight(_), OrderState::CancelInFlight(update)) => {
                 debug!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -170,9 +185,9 @@ where
                     update = ?snapshot,
                     "OrderManager transitioned an OpenInFlight order to CancelInFlight"
                 );
-                current_entry.get_mut().state = ActiveOrderState::CancelInFlight(update);
+                current_entry.get_mut().state = OrderState::CancelInFlight(update);
             }
-            (ActiveOrderState::Open(_), ActiveOrderState::OpenInFlight(_)) => {
+            (OrderState::Open(_), OrderState::OpenInFlight(_)) => {
                 warn!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -182,7 +197,7 @@ where
                     "OrderManager received an OpenInFlight recording for an Open order - ignoring"
                 );
             }
-            (ActiveOrderState::Open(current), ActiveOrderState::Open(update)) => {
+            (OrderState::Open(current), OrderState::Open(update)) => {
                 if current.time_exchange <= update.time_exchange {
                     debug!(
                         exchange = ?snapshot.key.exchange,
@@ -192,7 +207,7 @@ where
                         update = ?snapshot,
                         "OrderManager updating an Open order from a more recent snapshot"
                     );
-                    current_entry.get_mut().state = ActiveOrderState::Open(update);
+                    current_entry.get_mut().state = OrderState::Open(update);
                 } else {
                     debug!(
                         exchange = ?snapshot.key.exchange,
@@ -204,7 +219,7 @@ where
                     );
                 }
             }
-            (ActiveOrderState::Open(current), ActiveOrderState::CancelInFlight(mut update)) => {
+            (OrderState::Open(current), OrderState::CancelInFlight(mut update)) => {
                 debug!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -221,11 +236,11 @@ where
                     .filter(|update| current.time_exchange <= update.time_exchange)
                     .unwrap_or_else(|| current.clone());
 
-                current_entry.get_mut().state = ActiveOrderState::CancelInFlight(CancelInFlight {
+                current_entry.get_mut().state = OrderState::CancelInFlight(CancelInFlight {
                     order: Some(latest_open),
                 })
             }
-            (ActiveOrderState::CancelInFlight(_), ActiveOrderState::OpenInFlight(_)) => {
+            (OrderState::CancelInFlight(_), OrderState::OpenInFlight(_)) => {
                 error!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -235,7 +250,7 @@ where
                     "OrderManager received an OpenInFlight recording for a CancelInFlight - ignoring"
                 );
             }
-            (ActiveOrderState::CancelInFlight(current), ActiveOrderState::Open(update)) => {
+            (OrderState::CancelInFlight(current), OrderState::Open(update)) => {
                 debug!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -252,13 +267,12 @@ where
                     .is_none_or(|current| current.time_exchange <= update.time_exchange);
 
                 if update_open_is_latest {
-                    current_entry.get_mut().state =
-                        ActiveOrderState::CancelInFlight(CancelInFlight {
-                            order: Some(update),
-                        });
+                    current_entry.get_mut().state = OrderState::CancelInFlight(CancelInFlight {
+                        order: Some(update),
+                    });
                 }
             }
-            (ActiveOrderState::CancelInFlight(_), ActiveOrderState::CancelInFlight(_)) => {
+            (OrderState::CancelInFlight(_), OrderState::CancelInFlight(_)) => {
                 warn!(
                     exchange = ?snapshot.key.exchange,
                     instrument = ?snapshot.key.instrument,
@@ -267,6 +281,9 @@ where
                     update = ?snapshot,
                     "OrderManager received a duplicate CancelInFlight recording - ignoring"
                 );
+            }
+            _ => {
+                // unreachable: inactive states are handled before this match
             }
         }
     }
@@ -290,7 +307,7 @@ where
         };
 
         match (&order.get().state, &response.state) {
-            (ActiveOrderState::OpenInFlight(_) | ActiveOrderState::Open(_), Ok(_)) => {
+            (OrderState::OpenInFlight(_) | OrderState::Open(_), Ok(_)) => {
                 warn!(
                     exchange = ?response.key.exchange,
                     instrument = ?response.key.instrument,
@@ -301,7 +318,7 @@ where
                 );
                 order.remove();
             }
-            (ActiveOrderState::CancelInFlight(_), Ok(_)) => {
+            (OrderState::CancelInFlight(_), Ok(_)) => {
                 debug!(
                     exchange = ?response.key.exchange,
                     instrument = ?response.key.instrument,
@@ -312,7 +329,7 @@ where
                 );
                 order.remove();
             }
-            (ActiveOrderState::OpenInFlight(_) | ActiveOrderState::Open(_), Err(error)) => {
+            (OrderState::OpenInFlight(_) | OrderState::Open(_), Err(error)) => {
                 warn!(
                     exchange = ?response.key.exchange,
                     instrument = ?response.key.instrument,
@@ -323,7 +340,7 @@ where
                     "OrderManager received Err(Cancelled) for tracked order not CancelInFlight - ignoring"
                 );
             }
-            (ActiveOrderState::CancelInFlight(in_flight_cancel), Err(error)) => {
+            (OrderState::CancelInFlight(in_flight_cancel), Err(error)) => {
                 // Expected, keep move to Open
                 if let Some(open) = &in_flight_cancel.order {
                     debug!(
@@ -335,7 +352,7 @@ where
                         ?error,
                         "OrderManager received Err(Cancelled) for previously Open order - setting Open"
                     );
-                    order.get_mut().state = ActiveOrderState::Open(open.clone())
+                    order.get_mut().state = OrderState::Open(open.clone())
                 } else {
                     debug!(
                         exchange = ?response.key.exchange,
@@ -350,6 +367,9 @@ where
                     // -> it's expected that an Order snapshot is inbound
                     order.remove();
                 }
+            }
+            _ => {
+                // unreachable: inactive states are not stored
             }
         }
     }
@@ -374,7 +394,7 @@ where
             return;
         };
 
-        order.state = ActiveOrderState::CancelInFlight(CancelInFlight {
+        order.state = OrderState::CancelInFlight(CancelInFlight {
             order: order.state.open_meta().cloned(),
         });
     }
@@ -402,7 +422,7 @@ mod tests {
             Order, OrderKey, OrderKind, TimeInForce,
             id::{ClientOrderId, OrderId, StrategyId},
             request::{RequestCancel, RequestOpen},
-            state::{ActiveOrderState, CancelInFlight, Cancelled, Open, OpenInFlight},
+            state::{CancelInFlight, Cancelled, Expired, FullyFilled, Open, OpenInFlight},
         },
     };
     use barter_instrument::{Side, exchange::ExchangeId};
@@ -411,7 +431,7 @@ mod tests {
     use smol_str::SmolStr;
 
     fn orders(
-        orders: impl IntoIterator<Item = Order<ExchangeId, u64, ActiveOrderState>>,
+        orders: impl IntoIterator<Item = Order<ExchangeId, u64, OrderState>>,
     ) -> Orders<ExchangeId, u64> {
         Orders(
             orders
@@ -438,10 +458,10 @@ mod tests {
         }
     }
 
-    fn order_cancel_in_flight(cid: ClientOrderId) -> Order<ExchangeId, u64, ActiveOrderState> {
+    fn order_cancel_in_flight(cid: ClientOrderId) -> Order<ExchangeId, u64, OrderState> {
         order(
             cid,
-            ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+            OrderState::CancelInFlight(CancelInFlight { order: None }),
         )
     }
 
@@ -460,7 +480,7 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::inactive(Cancelled {
+            state: OrderState::Cancelled(Cancelled {
                 id: OrderId(SmolStr::default()),
                 time_exchange: Default::default(),
             }),
@@ -482,7 +502,7 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::fully_filled(),
+            state: OrderState::FullyFilled(FullyFilled),
         })
     }
 
@@ -501,7 +521,7 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::inactive(OrderError::Connectivity(ConnectivityError::Timeout)),
+            state: OrderState::OpenFailed(OrderError::Connectivity(ConnectivityError::Timeout)),
         })
     }
 
@@ -520,7 +540,7 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::expired(),
+            state: OrderState::Expired(Expired),
         })
     }
 
@@ -540,7 +560,7 @@ mod tests {
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
-            state: OrderState::active(open(time_exchange)),
+            state: OrderState::Open(open(time_exchange)),
         })
     }
 
@@ -566,7 +586,7 @@ mod tests {
 
     fn request_opens(
         orders: impl IntoIterator<Item = OrderRequestOpen<ExchangeId, u64>>,
-    ) -> FnvHashMap<ClientOrderId, Order<ExchangeId, u64, ActiveOrderState>> {
+    ) -> FnvHashMap<ClientOrderId, Order<ExchangeId, u64, OrderState>> {
         orders
             .into_iter()
             .map(|order| (order.key.cid.clone(), Order::from(&order)))
@@ -641,14 +661,14 @@ mod tests {
                 name: "untracked, Snapshot is active, so insert",
                 state: Orders::default(),
                 input: order_snapshot_open(cid.clone(), time_base),
-                expected: orders([order(cid.clone(), ActiveOrderState::from(open(time_base)))]),
+                expected: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
             },
             TestCase {
                 name: "untracked, Snapshot is active Open but fully filled, so ignore",
                 state: Orders::default(),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(Open {
+                    OrderState::Open(Open {
                         id: OrderId(SmolStr::default()),
                         time_exchange: time_base,
                         filled_quantity: dec!(1),
@@ -658,61 +678,49 @@ mod tests {
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is inactive cancelled, so remove",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: order_snapshot_cancelled(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is inactive fully filled, so remove",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: order_snapshot_fully_filled(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is inactive failed, so remove",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: order_snapshot_failed(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is inactive expired, so remove",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: order_snapshot_expired(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked Open, Snapshot is inactive cancelled, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: order_snapshot_cancelled(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked Open, Snapshot is inactive fully filled, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: order_snapshot_fully_filled(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked Open, Snapshot is inactive failed, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: order_snapshot_failed(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked Open, Snapshot is inactive expired, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: order_snapshot_expired(cid.clone()),
                 expected: Orders::default(),
             },
@@ -720,7 +728,7 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is inactive cancelled, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: order_snapshot_cancelled(cid.clone()),
                 expected: Orders::default(),
@@ -729,7 +737,7 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is inactive fully filled, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: order_snapshot_fully_filled(cid.clone()),
                 expected: Orders::default(),
@@ -738,7 +746,7 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is inactive failed, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: order_snapshot_failed(cid.clone()),
                 expected: Orders::default(),
@@ -747,32 +755,23 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is inactive expired, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: order_snapshot_expired(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is active OpenInFlight, so ignore duplicate",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
-                input: Snapshot(order(cid.clone(), OrderState::active(OpenInFlight))),
-                expected: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
+                input: Snapshot(order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))),
+                expected: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is active Open but fully filled, so remove",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(Open {
+                    OrderState::Open(Open {
                         id: OrderId(SmolStr::default()),
                         time_exchange: time_base,
                         filled_quantity: dec!(1),
@@ -782,76 +781,67 @@ mod tests {
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is active Open, so update",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: order_snapshot_open(cid.clone(), time_base),
-                expected: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                expected: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
             },
             TestCase {
                 name: "tracked OpenInFlight, Snapshot is active CancelInFlight, so update",
-                state: orders([order(
-                    cid.clone(),
-                    ActiveOrderState::OpenInFlight(OpenInFlight),
-                )]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
             },
             TestCase {
                 name: "tracked Open, Snapshot is active OpenInFlight, so ignore",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
-                input: Snapshot(order(cid.clone(), OrderState::active(OpenInFlight))),
-                expected: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
+                input: Snapshot(order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))),
+                expected: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
             },
             TestCase {
                 name: "tracked Open, Snapshot is active Open with newer time, so update",
-                state: orders([order(cid.clone(), ActiveOrderState::Open(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(ActiveOrderState::Open(open(time_plus_secs(time_base, 1)))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 1))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )]),
             },
             TestCase {
                 name: "tracked Open, Snapshot is active Open with older time, so ignore",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 1))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )]),
-                input: Snapshot(order(
-                    cid.clone(),
-                    OrderState::active(ActiveOrderState::Open(open(time_base))),
-                )),
+                input: Snapshot(order(cid.clone(), OrderState::Open(open(time_base)))),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 1))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )]),
             },
             TestCase {
                 name: "tracked Open, Snapshot is active CancelInFlight w/ newer Open, update accordingly",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 1))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )]),
@@ -860,17 +850,17 @@ mod tests {
                 name: "tracked Open, Snapshot is active CancelInFlight w/ older Open, update accordingly",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 2))),
+                    OrderState::Open(open(time_plus_secs(time_base, 2))),
                 )]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 1))),
                     }),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )]),
@@ -879,15 +869,15 @@ mod tests {
                 name: "tracked Open, Snapshot is active CancelInFlight w/ None Open, update accordingly",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::Open(open(time_plus_secs(time_base, 1))),
+                    OrderState::Open(open(time_plus_secs(time_base, 1))),
                 )]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 1))),
                     }),
                 )]),
@@ -896,24 +886,24 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is active OpenInFlight, so ignore",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
-                input: Snapshot(order(cid.clone(), OrderState::active(OpenInFlight))),
+                input: Snapshot(order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
             },
             TestCase {
                 name: "tracked CancelInFlight w/ None Open, Snapshot is active Open, update accordingly",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: order_snapshot_open(cid.clone(), time_base),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 0))),
                     }),
                 )]),
@@ -922,14 +912,14 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is active Open w/ older time, so ignore",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )]),
                 input: order_snapshot_open(cid.clone(), time_plus_secs(time_base, 1)),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )]),
@@ -938,14 +928,14 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is active Open w/ newer time, so update accordingly",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 1))),
                     }),
                 )]),
                 input: order_snapshot_open(cid.clone(), time_plus_secs(time_base, 2)),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_plus_secs(time_base, 2))),
                     }),
                 )]),
@@ -954,15 +944,15 @@ mod tests {
                 name: "tracked CancelInFlight, Snapshot is active CancelInFlight, so ignore duplicate",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: Snapshot(order(
                     cid.clone(),
-                    OrderState::active(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )),
                 expected: orders([order(
                     cid.clone(),
-                    ActiveOrderState::CancelInFlight(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
             },
         ];
@@ -994,13 +984,13 @@ mod tests {
             },
             TestCase {
                 name: "tracked OpenInFlight, response Ok, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::from(OpenInFlight))]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: response_cancel_ok(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked Open, response Ok, so remove",
-                state: orders([order(cid.clone(), ActiveOrderState::from(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: response_cancel_ok(cid.clone()),
                 expected: Orders::default(),
             },
@@ -1008,39 +998,39 @@ mod tests {
                 name: "tracked CancelInFlight, response Ok, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::from(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: response_cancel_ok(cid.clone()),
                 expected: Orders::default(),
             },
             TestCase {
                 name: "tracked OpenInFlight, response Err, so ignore",
-                state: orders([order(cid.clone(), ActiveOrderState::from(OpenInFlight))]),
+                state: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
                 input: response_cancel_err(cid.clone()),
-                expected: orders([order(cid.clone(), ActiveOrderState::from(OpenInFlight))]),
+                expected: orders([order(cid.clone(), OrderState::OpenInFlight(OpenInFlight))]),
             },
             TestCase {
                 name: "tracked Open, response Err, so ignore",
-                state: orders([order(cid.clone(), ActiveOrderState::from(open(time_base)))]),
+                state: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
                 input: response_cancel_err(cid.clone()),
-                expected: orders([order(cid.clone(), ActiveOrderState::from(open(time_base)))]),
+                expected: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
             },
             TestCase {
                 name: "tracked CancelInFlight w/ Some(Open), response Err, so set Open",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::from(CancelInFlight {
+                    OrderState::CancelInFlight(CancelInFlight {
                         order: Some(open(time_base)),
                     }),
                 )]),
                 input: response_cancel_err(cid.clone()),
-                expected: orders([order(cid.clone(), ActiveOrderState::from(open(time_base)))]),
+                expected: orders([order(cid.clone(), OrderState::Open(open(time_base)))]),
             },
             TestCase {
                 name: "tracked CancelInFlight w/ None Open, response Err, so remove",
                 state: orders([order(
                     cid.clone(),
-                    ActiveOrderState::from(CancelInFlight { order: None }),
+                    OrderState::CancelInFlight(CancelInFlight { order: None }),
                 )]),
                 input: response_cancel_err(cid),
                 expected: Orders::default(),

--- a/barter/src/execution/manager.rs
+++ b/barter/src/execution/manager.rs
@@ -18,7 +18,7 @@ use barter_execution::{
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Open, OrderState},
+        state::{FullyFilled, Open, OrderState},
     },
 };
 use barter_instrument::{
@@ -390,9 +390,11 @@ where
         let key = self.indexer.order_key(key)?;
 
         let state = match state {
-            Ok(open) if open.quantity_remaining(quantity).is_zero() => OrderState::fully_filled(),
-            Ok(open) => OrderState::active(open),
-            Err(error) => OrderState::inactive(self.indexer.order_error(error)?),
+            Ok(open) if open.quantity_remaining(quantity).is_zero() => {
+                OrderState::FullyFilled(FullyFilled)
+            }
+            Ok(open) => OrderState::Open(open),
+            Err(error) => OrderState::OpenFailed(self.indexer.order_error(error)?),
         };
 
         Ok(AccountStreamEvent::Item(AccountEvent {
@@ -423,7 +425,7 @@ where
                 quantity: state.quantity,
                 kind: state.kind,
                 time_in_force: state.time_in_force,
-                state: OrderState::inactive(OrderError::Connectivity(ConnectivityError::Timeout)),
+                state: OrderState::OpenFailed(OrderError::Connectivity(ConnectivityError::Timeout)),
             })),
         })
     }

--- a/barter/src/execution/manager.rs
+++ b/barter/src/execution/manager.rs
@@ -14,7 +14,7 @@ use barter_execution::{
     indexer::{AccountEventIndexer, IndexedAccountStream},
     map::ExecutionInstrumentMap,
     order::{
-        Order,
+        Order, UnindexedOrderSnapshot,
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
@@ -91,6 +91,10 @@ where
             "AccountStream with auto reconnect initialising"
         );
 
+        // TODO: Would it be possible for us to fetch the snapshots of known orders after the reconnect?
+        // Not requesting them from the engine. But initialize the fetch from here.
+        // We could probably be subscribed to account_stream and react on the reconnect event.
+
         // Initialise reconnecting IndexedAccountStream (snapshot + updates)
         let client_clone = Arc::clone(&client);
         let indexer_clone = indexer.clone();
@@ -145,6 +149,8 @@ where
                 client,
                 indexer,
             ),
+            // TODO: Do not return the merged account stream. The ExecutionManager should sanitize
+            // the events received before returning them to the subscriber
             merged_account_stream,
         ))
     }
@@ -221,6 +227,7 @@ where
     pub async fn run(mut self) {
         let mut in_flight_cancels = FuturesUnordered::new();
         let mut in_flight_opens = FuturesUnordered::new();
+        let mut in_flight_snapshots = FuturesUnordered::new();
 
         loop {
             let next_cancel_response = if in_flight_cancels.is_empty() {
@@ -235,10 +242,18 @@ where
                 Either::Right(in_flight_opens.select_next_some())
             };
 
+            let next_snapshot_response = if in_flight_snapshots.is_empty() {
+                Either::Left(std::future::pending())
+            } else {
+                Either::Right(in_flight_snapshots.select_next_some())
+            };
+
             tokio::select! {
                 // Process Engine ExecutionRequests
                 request = self.request_stream.next() => match request {
                     Some(ExecutionRequest::Shutdown) | None => {
+                        // TODO: The ExecutionManager should not shutdown until
+                        // we processed all in flight requests.
                         break;
                     }
                     Some(ExecutionRequest::Cancel(request)) => {
@@ -271,12 +286,37 @@ where
                             request,
                         ))
                     }
+                    Some(ExecutionRequest::Snapshots(requests)) => {
+                        let client_requests = requests.iter().map(|request| {
+                            // Panic since the system is set up incorrectly, so it's foolish to continue
+                            self.indexer
+                                .order_request(request)
+                                .unwrap_or_else(|error| panic!(
+                                    "ExecutionManager received snapshot request for non-configured key: {error}"
+                                ))
+                                .cloned_instrument()
+                        }).collect::<Vec<_>>();
+
+                        let futures = requests.into_iter()
+                            .zip(self.client.fetch_order_snapshots(client_requests))
+                            .map(|(request, response_fut)| RequestFuture::new(
+                                response_fut,
+                                self.request_timeout,
+                                request,
+                            ));
+
+                        in_flight_snapshots.extend(futures);
+                    }
                 },
 
                 // Process next ExecutionRequest::Cancel response
                 response_cancel = next_cancel_response => {
-                    match response_cancel {
+                    let (request, result) = response_cancel;
+                    match result {
                         Ok(Some(response)) => {
+                            // TODO: The response here doesn't definitively prove that the order
+                            // was cancelled. It's only an cancellation acknowledgment. The order can
+                            // still be filled while in process of being cancelled.
                             let event = match self.process_cancel_response(response) {
                                 Ok(indexed_event) => indexed_event,
                                 Err(error) => {
@@ -293,7 +333,11 @@ where
                                 break;
                             }
                         }
-                        Err(request) => {
+                        Err(_elapsed) => {
+                            // TODO: We should try again. The timeout happens
+                            // when we don't receive any response from the exchange.
+                            // That can mean anything. It doesn't mean that the order
+                            // was not cancelled.
                             let event = Self::process_cancel_timeout(request);
 
                             if self.response_tx.send(event).is_err() {
@@ -301,15 +345,21 @@ where
                             }
                         }
                         Ok(None) => {
-                            // Do nothing
+                            // TODO: Remove the Option return value. This was a temporary
+                            // hack indicating that the response result shouldn't be used
+                            // as an acknowledgment of the final status. This should be
+                            // removed and solved differently.
                         }
                     };
                 },
 
                 // Process next ExecutionRequest::Open response
                 response_open = next_open_response => {
-                    match response_open {
+                    let (request, result) = response_open;
+                    match result {
                         Ok(Some(response)) => {
+                            // TODO: The response here doesn't mean the order was actually opened. It's only an acknowledgment.
+                            // We should listen to the events received from the account stream.
                             let event = match self.process_open_response(response) {
                                 Ok(indexed_event) => indexed_event,
                                 Err(error) => {
@@ -326,7 +376,10 @@ where
                                 break;
                             }
                         }
-                        Err(request) => {
+                        Err(_elapsed) => {
+                            // TODO: We should check if the order was opened or not. In some cases
+                            // the request can timeout but the order was still opened. We should check
+                            // the status of the order on the exchange before publishing the order event.
                             let event = Self::process_open_timeout(request);
 
                             if self.response_tx.send(event).is_err() {
@@ -334,7 +387,57 @@ where
                             }
                         }
                         Ok(None) => {
-                            // Do nothing
+                            // TODO: Remove the Option return value. This was a temporary
+                            // hack indicating that the response result shouldn't be used
+                            // as an acknowledgment of the final status. This should be
+                            // solved differently.
+                        }
+                    }
+                }
+
+                // Process next ExecutionRequest::Snapshots response
+                response_snapshot = next_snapshot_response => {
+                    let (request, result) = response_snapshot;
+                    match result {
+                        Ok(Ok(response)) => {
+                            // TODO: The current snapshot was received from the exchange.
+                            // We should use this snapshot and check if the state on our side
+                            // corresponds to the state on the exchange.
+                            let event = match self.process_snapshot_response(response) {
+                                Ok(indexed_event) => indexed_event,
+                                Err(error) => {
+                                    warn!(
+                                        exchange = %self.indexer.map.exchange.value,
+                                        ?error,
+                                        "ExecutionManager filtering snapshot response due to unrecognised index"
+                                    );
+                                    continue
+                                }
+                            };
+
+                            if self.response_tx.send(event).is_err() {
+                                break;
+                            }
+                        }
+                        Ok(Err(error)) => {
+                            // TODO: It depends on the error. In some cases we should try again.
+                            // In other we can say that the order does not exist.
+                            warn!(
+                                exchange = %self.indexer.map.exchange.value,
+                                ?request,
+                                ?error,
+                                "ExecutionManager fetch_order_snapshot failed"
+                            );
+                        }
+                        Err(_elapsed) => {
+                            // TODO: We should always try again. The timeout happens
+                            // when we don't receive any response from the exchange.
+                            // That can mean anything. We should try again
+                            warn!(
+                                exchange = %self.indexer.map.exchange.value,
+                                ?request,
+                                "ExecutionManager fetch_order_snapshot timed out"
+                            );
                         }
                     }
                 }
@@ -371,6 +474,18 @@ where
                 state: Err(OrderError::Connectivity(ConnectivityError::Timeout)),
             }),
         })
+    }
+
+    fn process_snapshot_response(
+        &self,
+        order: UnindexedOrderSnapshot,
+    ) -> Result<AccountStreamEvent, IndexError> {
+        let order = self.indexer.order_snapshot(order)?;
+
+        Ok(AccountStreamEvent::Item(AccountEvent {
+            exchange: order.key.exchange,
+            kind: AccountEventKind::OrderSnapshot(Snapshot(order)),
+        }))
     }
 
     fn process_open_response(

--- a/barter/src/execution/request.rs
+++ b/barter/src/execution/request.rs
@@ -1,4 +1,6 @@
-use barter_execution::order::request::{OrderRequestCancel, OrderRequestOpen};
+use barter_execution::order::request::{
+    OrderRequestCancel, OrderRequestOpen, OrderRequestSnapshot,
+};
 use barter_instrument::{exchange::ExchangeIndex, instrument::InstrumentIndex};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
@@ -17,40 +19,47 @@ pub enum ExecutionRequest<ExchangeKey = ExchangeIndex, InstrumentKey = Instrumen
     /// Request to cancel an existing `Order`.
     Cancel(OrderRequestCancel<ExchangeKey, InstrumentKey>),
 
-    /// Request to open an new `Order`.
+    /// Request to open a new `Order`.
     Open(OrderRequestOpen<ExchangeKey, InstrumentKey>),
+
+    /// Request the current state of `Order`s.
+    Snapshots(Vec<OrderRequestSnapshot<ExchangeKey, InstrumentKey>>),
 }
 
 #[derive(Debug)]
 #[pin_project::pin_project]
-pub(super) struct RequestFuture<Request, ResponseFut> {
-    request: Request,
+pub struct RequestFuture<Request, ResponseFut> {
+    /// Returned paired with the response when this future resolves. Stored as `Option` to move out
+    /// on completion rather than clone.
+    request: Option<Request>,
     #[pin]
-    response_future: tokio::time::Timeout<ResponseFut>,
+    response_future: ResponseFut,
 }
 
 impl<Request, ResponseFut> Future for RequestFuture<Request, ResponseFut>
 where
-    Request: Clone,
     ResponseFut: Future,
 {
-    type Output = Result<ResponseFut::Output, Request>;
+    type Output = (Request, ResponseFut::Output);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        this.response_future
-            .poll(cx)
-            .map(|result| result.map_err(|_| this.request.clone()))
+        this.response_future.poll(cx).map(|result| {
+            (
+                this.request.take().expect("the request is always set"),
+                result,
+            )
+        })
     }
 }
 
-impl<Request, ResponseFut> RequestFuture<Request, ResponseFut>
+impl<Request, F> RequestFuture<Request, tokio::time::Timeout<F>>
 where
-    ResponseFut: Future,
+    F: Future,
 {
-    pub fn new(future: ResponseFut, timeout: std::time::Duration, request: Request) -> Self {
+    pub fn new(future: F, timeout: std::time::Duration, request: Request) -> Self {
         Self {
-            request,
+            request: Some(request),
             response_future: tokio::time::timeout(timeout, future),
         }
     }

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -47,7 +47,7 @@ use barter_execution::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, RequestOpen},
-        state::{ActiveOrderState, Open, OrderState},
+        state::{FullyFilled, Open, OrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -531,7 +531,7 @@ fn test_engine_process_engine_event_with_audit() {
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: true },
-            state: ActiveOrderState::Open(Open {
+            state: OrderState::Open(Open {
                 id: gen_order_id(1),
                 time_exchange: time_plus_days(STARTING_TIMESTAMP, 4),
                 filled_quantity: dec!(0),
@@ -572,7 +572,7 @@ fn test_engine_process_engine_event_with_audit() {
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: true },
-            state: OrderState::fully_filled(),
+            state: OrderState::FullyFilled(FullyFilled),
         })),
     }));
     let audit = process_with_audit(&mut engine, event.clone());
@@ -915,7 +915,7 @@ fn account_event_order_response(
             quantity: Decimal::try_from(quantity).unwrap(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: true },
-            state: OrderState::active(Open {
+            state: OrderState::Open(Open {
                 id: gen_order_id(instrument),
                 time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
                 filled_quantity: Decimal::try_from(filled).unwrap(),

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -873,7 +873,6 @@ fn account_event_snapshot(assets: &AssetStates) -> EngineEvent<DataKind> {
                     time_exchange: state.balance.unwrap().time,
                 })
                 .collect(),
-            instruments: vec![],
         }),
     }))
 }


### PR DESCRIPTION
First steps to a vision of reliable ExecutionManager. I opened this PR so that we can align on the vision and ideas on how to proceed forward, before investing too much time.

I think the ExecutionManager's task should be tracking and managing orders states and lifetimes. The events pushed from the managers in [this](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs#L56) channel should be consistent and already sanitized before they are published to the engine. Using this approach, we can guarantee that the execution events are processed by the engine/strategy in the correct order. This is the only way the strategy can reliably act on the information relayed by the order events.

The manager should guarantee the correct lifetime of the order. That means if we missed any events during the reconnect a manager should correctly handle those missing events. e.g. the trade that was missing in reconnect should be published nevertheless, order finalization status should only be published after the order is actually finalized, ....

I've added TODOs in the [manager.rs](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs) specifying some of the edge cases that will eventually be handled:
* [link](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs#L94) - fetch order snapshots for all known orders by the manager. Only fetching open orders was not enough because the order could already be filled while we reconnected. We have to check the states of all managed orders. 
* [link](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs#L255) - the manager should wait with the shutdown while there are any order requests in progress. The engine could have initialized cancelation of all orders before shutting down. The manager should facilitate a successful cancelation of those orders before shutting down.
* [cancel link](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs#L337) [open link](https://github.com/barter-rs/barter-rs/blob/eb1148a60861f35f8ea9df6415363f665f9748e6/barter/src/execution/manager.rs#L380) - the timeouts shouldn't be returned to the engine. The manager should check what is the status of the order on the exchange before notifying the engine. The timeout doesn't mean that the order was not created or cancelled.