### PR TITLE
fix(integration/websocket): skip application-level text ping/pong

### DIFF
--- a/barter-integration/src/protocol/websocket/mod.rs
+++ b/barter-integration/src/protocol/websocket/mod.rs
@@ -124,12 +124,20 @@ where
 }
 
 /// Process a payload of `String` by deserialising into an `ExchangeMessage`.
+///
+/// Application-level text `ping`/`pong` (e.g. OKX) is skipped, matching protocol Ping/Pong.
 pub fn process_text<ExchangeMessage>(
     payload: Utf8Bytes,
 ) -> Option<Result<ExchangeMessage, SocketError>>
 where
     ExchangeMessage: for<'de> Deserialize<'de>,
 {
+    let trimmed = payload.trim();
+    if trimmed.eq_ignore_ascii_case("ping") || trimmed.eq_ignore_ascii_case("pong") {
+        debug!(?payload, "received ping/pong WebSocket text");
+        return None;
+    }
+
     Some(
         serde_json::from_str::<ExchangeMessage>(&payload).map_err(|error| {
             debug!(
@@ -277,5 +285,35 @@ mod tests {
         let msg = Err(WsError::ConnectionClosed);
         let result = WsParser::parse(msg);
         assert!(matches!(result, Message::Admin(AdminWs::WsError(_))));
+    }
+
+    #[test]
+    fn test_process_text_skips_application_ping_pong() {
+        for payload in ["pong", "ping", "PONG", " pong "] {
+            let result = process_text::<serde_json::Value>(payload.into());
+            assert!(
+                result.is_none(),
+                "expected None for application-level ping/pong {payload:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_process_text_deserialises_json_object() {
+        let result = process_text::<serde_json::Value>(r#"{"ok":true}"#.into());
+        assert!(matches!(result, Some(Ok(value)) if value == serde_json::json!({"ok": true})));
+    }
+
+    #[test]
+    fn test_websocket_serde_parser_skips_text_pong() {
+        let result: Option<Result<serde_json::Value, SocketError>> =
+            WebSocketSerdeParser::parse(Ok(WsMessage::Text("pong".into())));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_process_text_invalid_json_still_errors() {
+        let result = process_text::<serde_json::Value>("not-json".into());
+        assert!(matches!(result, Some(Err(SocketError::Deserialise { .. }))));
     }
 }


### PR DESCRIPTION
## Problem

OKX `ping_interval()` sends an application-level text `ping` every 29s. The exchange replies with a **text frame** whose payload is the literal string `pong` (not JSON).

`WebSocketSerdeParser::process_text` JSON-deserialises every text frame, so those heartbeats become stream errors:

```
Socket("Deserialising JSON error: expected value at line 1 column 1 for payload: pong")
```

This is the OKX half of #205. Protocol-level Ping/Pong opcodes were already skipped; application-level text was not.

## Fix

Before `serde_json::from_str`, skip text payloads that are exactly `ping`/`pong` (trimmed, ASCII case-insensitive) and return `None`, matching `process_ping`/`process_pong`. JSON objects still go through serde.

Bybit JSON pongs (`{"success":true,"ret_msg":"pong","op":"ping"}`) are intentionally unchanged — they are covered by #279.

## Tests

- skip `pong` / `ping` / `PONG` / ` pong `
- still deserialise `{"ok":true}`
- `WebSocketSerdeParser` skips `Text("pong")`
- non-ping invalid JSON still returns `Deserialise`

`cargo test -p barter-integration --lib -- protocol::websocket` — 10 passed.


Made with [Cursor](https://cursor.com)