### PR TITLE
fix: sweep findings + CI retarget to main + release bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on:
   push:
     paths-ignore:
       - "**.md"
-    branches: ["develop"]
+    branches: ["main"]
   pull_request:
-    branches: ["develop"]
+    branches: ["main"]
     paths-ignore:
       - "**.md"
 
@@ -50,6 +50,10 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          # dev-profile debug info overflows DWARF32 linking the large
+          # examples under rust-lld on CI runners
+          CARGO_PROFILE_DEV_DEBUG: "0"
         with:
           command: test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 # Barter Ecosystem
 barter-integration = { path = "./barter-integration", version = "0.11" }
 barter-instrument = { path = "./barter-instrument", version = "0.3" }
-barter-data = { path = "./barter-data", version = "0.11" }
+barter-data = { path = "./barter-data", version = "0.12" }
 barter-execution = { path = "./barter-execution", version = "0.7" }
 barter-macro = { path = "./barter-macro", version = "0.2.0" }
 

--- a/barter-data/Cargo.toml
+++ b/barter-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter-data"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["JustAStream <justastream.code@gmail.com>"]
 license = "MIT"

--- a/barter-data/src/books/mod.rs
+++ b/barter-data/src/books/mod.rs
@@ -179,7 +179,7 @@ impl OrderBookSide<Asks> {
         L: Into<Level>,
     {
         let mut levels = levels.into_iter().map(L::into).collect::<Vec<_>>();
-        levels.sort_unstable_by(|a, b| a.price.cmp(&b.price));
+        levels.sort_unstable_by_key(|level| level.price);
 
         Self { side: Asks, levels }
     }

--- a/barter-data/src/exchange/gateio/future/mod.rs
+++ b/barter-data/src/exchange/gateio/future/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     NoInitialSnapshots,
     exchange::{
         ExchangeServer, StreamSelector,
-        gateio::{Gateio, GateiotWsStream, perpetual::trade::GateioFuturesTrades},
+        gateio::{Gateio, GateioWsStream, perpetual::trade::GateioFuturesTrades},
     },
     instrument::InstrumentData,
     subscription::trade::PublicTrades,
@@ -36,7 +36,7 @@ where
     Instrument: InstrumentData,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream = GateiotWsStream<
+    type Stream = GateioWsStream<
         StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioFuturesTrades>,
     >;
 }
@@ -72,7 +72,7 @@ where
     Instrument: InstrumentData,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream = GateiotWsStream<
+    type Stream = GateioWsStream<
         StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioFuturesTrades>,
     >;
 }

--- a/barter-data/src/exchange/gateio/mod.rs
+++ b/barter-data/src/exchange/gateio/mod.rs
@@ -48,7 +48,7 @@ pub mod message;
 pub mod subscription;
 
 /// Convenient type alias using [`WebSocketSerdeParser`](barter_integration::protocol::websocket::WebSocketSerdeParser).
-pub type GateiotWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
+pub type GateioWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
 
 /// Generic [`Gateio<Server>`](Gateio) exchange.
 ///

--- a/barter-data/src/exchange/gateio/option/mod.rs
+++ b/barter-data/src/exchange/gateio/option/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     NoInitialSnapshots,
     exchange::{
         ExchangeServer, StreamSelector,
-        gateio::{Gateio, GateiotWsStream, perpetual::trade::GateioFuturesTrades},
+        gateio::{Gateio, GateioWsStream, perpetual::trade::GateioFuturesTrades},
     },
     instrument::InstrumentData,
     subscription::trade::PublicTrades,
@@ -36,7 +36,7 @@ where
     Instrument: InstrumentData,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream = GateiotWsStream<
+    type Stream = GateioWsStream<
         StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioFuturesTrades>,
     >;
 }

--- a/barter-data/src/exchange/gateio/perpetual/mod.rs
+++ b/barter-data/src/exchange/gateio/perpetual/mod.rs
@@ -2,7 +2,7 @@ use self::trade::GateioFuturesTrades;
 use super::Gateio;
 use crate::{
     NoInitialSnapshots,
-    exchange::{ExchangeServer, StreamSelector, gateio::GateiotWsStream},
+    exchange::{ExchangeServer, StreamSelector, gateio::GateioWsStream},
     instrument::InstrumentData,
     subscription::trade::PublicTrades,
     transformer::stateless::StatelessTransformer,
@@ -38,7 +38,7 @@ where
     Instrument: InstrumentData,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream = GateiotWsStream<
+    type Stream = GateioWsStream<
         StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioFuturesTrades>,
     >;
 }
@@ -74,7 +74,7 @@ where
     Instrument: InstrumentData,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream = GateiotWsStream<
+    type Stream = GateioWsStream<
         StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioFuturesTrades>,
     >;
 }

--- a/barter-data/src/exchange/gateio/spot/mod.rs
+++ b/barter-data/src/exchange/gateio/spot/mod.rs
@@ -2,7 +2,7 @@ use self::trade::GateioSpotTrade;
 use super::Gateio;
 use crate::{
     NoInitialSnapshots,
-    exchange::{ExchangeServer, StreamSelector, gateio::GateiotWsStream},
+    exchange::{ExchangeServer, StreamSelector, gateio::GateioWsStream},
     instrument::InstrumentData,
     subscription::trade::PublicTrades,
     transformer::stateless::StatelessTransformer,
@@ -42,7 +42,7 @@ where
 {
     type SnapFetcher = NoInitialSnapshots;
     type Stream =
-        GateiotWsStream<StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioSpotTrade>>;
+        GateioWsStream<StatelessTransformer<Self, Instrument::Key, PublicTrades, GateioSpotTrade>>;
 }
 
 impl Display for GateioSpot {

--- a/barter-data/src/streams/builder/dynamic/mod.rs
+++ b/barter-data/src/streams/builder/dynamic/mod.rs
@@ -393,7 +393,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
-                                                        BybitSpot::default(),
+                                                        BybitPerpetualsUsd::default(),
                                                         sub.instrument,
                                                         OrderBooksL1,
                                                     )
@@ -413,7 +413,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
-                                                        BybitSpot::default(),
+                                                        BybitPerpetualsUsd::default(),
                                                         sub.instrument,
                                                         OrderBooksL2,
                                                     )

--- a/barter-instrument/Cargo.toml
+++ b/barter-instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter-instrument"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["JustAStream <justastream.code@gmail.com>"]
 license = "MIT"

--- a/barter-instrument/src/index/mod.rs
+++ b/barter-instrument/src/index/mod.rs
@@ -137,7 +137,7 @@ impl IndexedInstruments {
     /// * `name` - The `InstrumentNameInternal` associated with the instrument (eg/ binance_spot_btc_usdt).
     ///
     /// # Returns
-    /// * `Ok(AssetIndex)` - instrument found.
+    /// * `Ok(InstrumentIndex)` - instrument found.
     /// * `Err(IndexError)` - instrument not found.
     pub fn find_instrument_index(
         &self,
@@ -150,9 +150,9 @@ impl IndexedInstruments {
                 (indexed.value.exchange.value == exchange && indexed.value.name_internal == *name)
                     .then_some(indexed.key)
             })
-            .ok_or(IndexError::AssetIndex(format!(
-                "Asset: ({}, {}) is not present in indexed instrument assets: {:?}",
-                exchange, name, self.assets
+            .ok_or(IndexError::InstrumentIndex(format!(
+                "Instrument: ({}, {}) is not present in indexed instruments: {:?}",
+                exchange, name, self.instruments
             )))
     }
 
@@ -372,14 +372,14 @@ mod tests {
         let err = indexed
             .find_instrument_index(ExchangeId::Kraken, &btc_usdt)
             .unwrap_err();
-        assert!(matches!(err, IndexError::AssetIndex(_)));
+        assert!(matches!(err, IndexError::InstrumentIndex(_)));
 
         // Test finding non-existent instrument
         let nonexistent = InstrumentNameInternal::from("nonexistent");
         let err = indexed
             .find_instrument_index(ExchangeId::BinanceSpot, &nonexistent)
             .unwrap_err();
-        assert!(matches!(err, IndexError::AssetIndex(_)));
+        assert!(matches!(err, IndexError::InstrumentIndex(_)));
     }
 
     #[test]

--- a/barter/Cargo.toml
+++ b/barter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter"
-version = "0.12.5"
+version = "0.13.0"
 edition = "2024"
 authors = ["JustAStream <justastream.code@gmail.com>"]
 license = "MIT"

--- a/barter/src/engine/state/instrument/data.rs
+++ b/barter/src/engine/state/instrument/data.rs
@@ -93,10 +93,8 @@ impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
                         .replace(Timed::new(price, event.time_exchange));
                 }
             }
-            DataKind::OrderBookL1(l1) => {
-                if self.l1.last_update_time < event.time_exchange {
-                    self.l1 = l1.clone()
-                }
+            DataKind::OrderBookL1(l1) if self.l1.last_update_time < event.time_exchange => {
+                self.l1 = l1.clone()
             }
             _ => {}
         }


### PR DESCRIPTION
Three bug fixes surfaced by an automated convention sweep, preceded by the CI repairs they exposed, and followed by the semver cascade they cause. One commit each, in reading order:

1. **`ci:`** — CI listened only for `develop` pushes/PRs, but `develop` was abandoned 39 commits ago: no gate has run on any recent change while release-plz auto-publishes from every `main` push. CI now targets `main` (push + PR), landing in front of the release pipeline; its test job builds without debug info to dodge the DWARF32 overflow on the large examples.
2. **`chore(clippy)`** — clears the two warnings that accumulated while CI was blind (`sort_unstable_by_key` in `books`, a match-guard collapse in engine instrument data), so the `-D warnings` gate lands green.
3. **`fix(index)`** — `find_instrument_index` misses returned `IndexError::AssetIndex` with an `"Asset: …"` message dumping `self.assets` (copy-pasted from the asset helper). Now `IndexError::InstrumentIndex`, naming the instrument, dumping `self.instruments`; doc `Returns` line and the two tests that encoded the wrong variant corrected with it.
4. **`fix(gateio)!`** — `GateiotWsStream` → `GateioWsStream` (definition + 8 use sites). **Breaking**: the misspelt `pub type` shipped in barter-data v0.11.0.
5. **`fix(streams)`** — the dynamic builder's `(BybitPerpetualsUsd, OrderBooksL1/L2)` arms constructed subscriptions with `BybitSpot::default()`, routing perpetuals book subscriptions to the spot connector. The `PublicTrades` arm was already correct.
6. **`chore(release)`** — manual semver cascade (release-plz's release-pr job is currently failing, so it will not open the bump PR): barter-data **0.12.0** (breaking), barter **0.13.0** (exposes barter-data types publicly), barter-instrument **0.3.2** (patch). barter-execution does not depend on barter-data — no bump; integration/macro untouched.

On merge, release-plz publishes barter-data 0.12.0, barter-instrument 0.3.2 and barter 0.13.0 to crates.io. Cargo.lock is untracked in this repo, so the bumps need no lockfile commit. CI ran green on this branch's tree.