### PR TITLE
fix: barter-execution 0.8.0 completes the release cascade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 barter-integration = { path = "./barter-integration", version = "0.11" }
 barter-instrument = { path = "./barter-instrument", version = "0.3" }
 barter-data = { path = "./barter-data", version = "0.12" }
-barter-execution = { path = "./barter-execution", version = "0.7" }
+barter-execution = { path = "./barter-execution", version = "0.8" }
 barter-macro = { path = "./barter-macro", version = "0.2.0" }
 
 # Logging

--- a/barter-execution/Cargo.toml
+++ b/barter-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter-execution"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["JustAStream <justastream.code@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Yesterday's merge published barter-data 0.12.0 and barter-instrument 0.3.2, but **barter 0.13.0 failed to publish**: its verification build pulled crates.io's `barter-execution 0.7.0`, which was published when the workspace still pinned `barter-integration 0.10`. The workspace later moved to integration 0.11 without execution ever being re-released — local 0.7.0 no longer matches published 0.7.0 — so the build mixed two integration versions and died on type-identity mismatches (`expected Snapshot<&Order>, found a different Snapshot<&Order>`).

Fix: bump barter-execution to **0.8.0** (its published dependency set changes incompatibly, and it exposes integration types publicly) and move the root workspace requirement to `"0.8"`. On merge, release-plz publishes execution 0.8.0 and then barter 0.13.0 in dependency order.

Verified locally: `check`/`clippy` clean, full `cargo test --all-features` green (13 suites). Note: the separate `Release-plz PR` job still fails on its own pre-existing `install-action requires bash` issue — unrelated to publishing, same as before.