### PR TITLE
fix(integration)!: extend keeps the order it was given

### DIFF
--- a/barter-integration/src/collection/none_one_or_many.rs
+++ b/barter-integration/src/collection/none_one_or_many.rs
@@ -163,11 +163,14 @@ impl<T> From<Vec<T>> for NoneOneOrMany<T> {
 // Create NoneOneOrMany from an iterator
 impl<T> FromIterator<T> for NoneOneOrMany<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut collection = iter.into_iter().collect::<Vec<_>>();
-        match collection.len() {
-            0 => Self::None,
-            1 => Self::One(collection.swap_remove(0)),
-            _ => Self::Many(collection),
+        let mut iter = iter.into_iter();
+
+        match (iter.next(), iter.next()) {
+            (None, _) => Self::None,
+            (Some(first), None) => Self::One(first),
+            (Some(first), Some(second)) => {
+                Self::Many(once(first).chain(once(second)).chain(iter).collect())
+            }
         }
     }
 }
@@ -293,6 +296,24 @@ mod tests {
         assert!(NoneOneOrMany::One(1).extend([2]).into_vec().capacity() <= 2);
         assert!(NoneOneOrMany::None.extend([1, 2]).into_vec().capacity() <= 2);
         assert!(NoneOneOrMany::One(1).extend([2, 3]).into_vec().capacity() <= 3);
+    }
+
+    #[test]
+    fn collecting_lands_in_the_smallest_variant_that_fits() {
+        assert_eq!(
+            NoneOneOrMany::from_iter(std::iter::empty::<u8>()),
+            NoneOneOrMany::None
+        );
+        assert_eq!(NoneOneOrMany::from_iter([1]), NoneOneOrMany::One(1));
+        assert_eq!(
+            NoneOneOrMany::from_iter([1, 2]),
+            NoneOneOrMany::Many(vec![1, 2])
+        );
+        assert_eq!(
+            NoneOneOrMany::from_iter([1, 2, 3]).into_vec(),
+            vec![1, 2, 3],
+            "collecting preserves order"
+        );
     }
 
     #[test]

--- a/barter-integration/src/collection/none_one_or_many.rs
+++ b/barter-integration/src/collection/none_one_or_many.rs
@@ -3,7 +3,7 @@ use itertools::Either;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::{Borrow, BorrowMut},
-    iter::{FromIterator, IntoIterator},
+    iter::{FromIterator, IntoIterator, once},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize)]
@@ -27,30 +27,31 @@ impl<T> NoneOneOrMany<T> {
         }
     }
 
+    #[must_use]
     pub fn extend<Iter>(self, other: Iter) -> Self
     where
         Iter: IntoIterator<Item = T>,
     {
-        let other = Self::from_iter(other);
+        let mut other = other.into_iter();
 
-        use NoneOneOrMany::*;
-        match (self, other) {
-            (None, right) => right,
-            (left, None) => left,
-            (One(left), One(right)) => Many(vec![left, right]),
-            (One(left), Many(mut right)) => {
-                right.push(left);
-                Many(right)
+        let Some(first) = other.next() else {
+            return self;
+        };
+
+        // Chained so the Vec is sized once from the whole sequence: growing a One
+        // through into_vec would take a Vec of one and immediately reallocate
+        // for the second item.
+        Self::Many(match self {
+            Self::None => match other.next() {
+                None => return Self::One(first),
+                Some(second) => once(first).chain(once(second)).chain(other).collect(),
+            },
+            Self::One(item) => once(item).chain(once(first)).chain(other).collect(),
+            Self::Many(mut items) => {
+                items.extend(once(first).chain(other));
+                items
             }
-            (Many(mut left), One(right)) => {
-                left.push(right);
-                Many(left)
-            }
-            (Many(mut left), Many(right)) => {
-                left.extend(right);
-                Many(left)
-            }
-        }
+        })
     }
 
     pub fn contains(&self, item: &T) -> bool
@@ -208,5 +209,99 @@ impl<'a, T> IntoIterator for &'a mut NoneOneOrMany<T> {
             NoneOneOrMany::One(item) => Either::Right(Either::Left(std::iter::once(item))),
             NoneOneOrMany::Many(items) => Either::Right(Either::Right(items.iter_mut())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extend_appends_the_right_side_after_the_left() {
+        assert_eq!(
+            NoneOneOrMany::One(1).extend([2, 3]),
+            NoneOneOrMany::Many(vec![1, 2, 3])
+        );
+        assert_eq!(
+            NoneOneOrMany::Many(vec![1, 2]).extend([3]),
+            NoneOneOrMany::Many(vec![1, 2, 3])
+        );
+        assert_eq!(
+            NoneOneOrMany::Many(vec![1, 2]).extend([3, 4]),
+            NoneOneOrMany::Many(vec![1, 2, 3, 4])
+        );
+        assert_eq!(
+            NoneOneOrMany::One(1).extend([2]),
+            NoneOneOrMany::Many(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn extend_with_nothing_leaves_the_left_side_untouched() {
+        assert_eq!(NoneOneOrMany::<u8>::None.extend([]), NoneOneOrMany::None);
+        assert_eq!(NoneOneOrMany::One(1).extend([]), NoneOneOrMany::One(1));
+        assert_eq!(
+            NoneOneOrMany::Many(vec![1, 2]).extend([]),
+            NoneOneOrMany::Many(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn extending_none_lands_in_the_smallest_variant_that_fits() {
+        assert_eq!(NoneOneOrMany::None.extend([1]), NoneOneOrMany::One(1));
+        assert_eq!(
+            NoneOneOrMany::None.extend([1, 2]),
+            NoneOneOrMany::Many(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn extend_leaves_an_empty_many_on_the_left_where_it_found_it() {
+        // {"Many":[]} arrives by deserialisation, and extend does not normalise
+        // it away. The derived PartialEq, Ord and Hash all read the variant, so
+        // Many([1]) and One(1) are different values.
+        assert_eq!(
+            NoneOneOrMany::Many(Vec::new()).extend([1]),
+            NoneOneOrMany::Many(vec![1])
+        );
+        assert_ne!(NoneOneOrMany::Many(vec![1]), NoneOneOrMany::One(1));
+    }
+
+    #[test]
+    fn extend_sizes_correctly_when_the_iterator_under_reports() {
+        // Every other test feeds an ExactSizeIterator. A filter reports a lower
+        // bound of zero, so the Vec cannot be sized from the hint alone.
+        let under_reporting = vec![2, 3].into_iter().filter(|_| true);
+
+        assert_eq!(
+            NoneOneOrMany::One(1).extend(under_reporting),
+            NoneOneOrMany::Many(vec![1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn extend_stepwise_matches_extend_at_once() {
+        let stepwise = NoneOneOrMany::None.extend([1]).extend([2]).extend([3]);
+        let at_once = NoneOneOrMany::None.extend([1, 2, 3]);
+
+        assert_eq!(stepwise, at_once);
+        assert_eq!(stepwise.into_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn extend_buys_one_vec_of_the_size_it_needs() {
+        assert!(NoneOneOrMany::One(1).extend([2]).into_vec().capacity() <= 2);
+        assert!(NoneOneOrMany::None.extend([1, 2]).into_vec().capacity() <= 2);
+        assert!(NoneOneOrMany::One(1).extend([2, 3]).into_vec().capacity() <= 3);
+    }
+
+    #[test]
+    fn an_empty_collection_answers_for_itself() {
+        let none = NoneOneOrMany::<u8>::None;
+
+        assert_eq!(none.len(), 0);
+        assert!(none.is_empty());
+        assert_eq!(none.as_ref(), &[] as &[u8]);
+        assert_eq!(none.into_option(), None);
     }
 }

--- a/barter-integration/src/collection/one_or_many.rs
+++ b/barter-integration/src/collection/one_or_many.rs
@@ -150,10 +150,14 @@ impl<T> From<NoneOneOrMany<T>> for Option<OneOrMany<T>> {
 // FromIterator implementation
 impl<T> FromIterator<T> for OneOrMany<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut collection = iter.into_iter().collect::<Vec<_>>();
-        match collection.len() {
-            1 => Self::One(collection.swap_remove(0)),
-            _ => Self::Many(collection),
+        let mut iter = iter.into_iter();
+
+        match (iter.next(), iter.next()) {
+            (None, _) => Self::Many(Vec::new()),
+            (Some(first), None) => Self::One(first),
+            (Some(first), Some(second)) => {
+                Self::Many(once(first).chain(once(second)).chain(iter).collect())
+            }
         }
     }
 }
@@ -272,6 +276,31 @@ mod tests {
     fn extend_buys_one_vec_of_the_size_it_needs() {
         assert!(OneOrMany::One(1).extend([2]).into_vec().capacity() <= 2);
         assert!(OneOrMany::One(1).extend([2, 3]).into_vec().capacity() <= 3);
+    }
+
+    #[test]
+    fn collecting_one_item_carries_no_vec() {
+        let one = OneOrMany::from_iter([1]);
+
+        assert_eq!(one, OneOrMany::One(1));
+        assert!(one.is_one());
+    }
+
+    #[test]
+    fn collecting_lands_in_the_variant_the_count_calls_for() {
+        assert_eq!(OneOrMany::from_iter([1, 2]), OneOrMany::Many(vec![1, 2]));
+        assert_eq!(
+            OneOrMany::from_iter([1, 2, 3]).into_vec(),
+            vec![1, 2, 3],
+            "collecting preserves order"
+        );
+        // Undecided: the type says non-empty, but From<Vec<T>> panics on empty
+        // while this door returns an empty Many. Pinned so it cannot drift
+        // silently before that is settled.
+        assert_eq!(
+            OneOrMany::from_iter(std::iter::empty::<u8>()),
+            OneOrMany::Many(vec![])
+        );
     }
 
     #[test]

--- a/barter-integration/src/collection/one_or_many.rs
+++ b/barter-integration/src/collection/one_or_many.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::{Borrow, BorrowMut},
     convert::AsRef,
+    iter::once,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
@@ -24,28 +25,27 @@ impl<T> OneOrMany<T> {
         }
     }
 
+    #[must_use]
     pub fn extend<Iter>(self, other: Iter) -> Self
     where
         Iter: IntoIterator<Item = T>,
     {
-        let other = Self::from_iter(other);
+        let mut other = other.into_iter();
 
-        use OneOrMany::*;
-        match (self, other) {
-            (One(left), One(right)) => Many(vec![left, right]),
-            (One(left), Many(mut right)) => {
-                right.push(left);
-                Many(right)
+        let Some(first) = other.next() else {
+            return self;
+        };
+
+        // Chained so the Vec is sized once from the whole sequence: growing a One
+        // through into_vec would take a Vec of one and immediately reallocate
+        // for the second item.
+        Self::Many(match self {
+            Self::One(item) => once(item).chain(once(first)).chain(other).collect(),
+            Self::Many(mut items) => {
+                items.extend(once(first).chain(other));
+                items
             }
-            (Many(mut left), One(right)) => {
-                left.push(right);
-                Many(left)
-            }
-            (Many(mut left), Many(right)) => {
-                left.extend(right);
-                Many(left)
-            }
-        }
+        })
     }
 
     pub fn contains(&self, item: &T) -> bool
@@ -194,5 +194,93 @@ impl<'a, T> IntoIterator for &'a mut OneOrMany<T> {
             OneOrMany::One(item) => Either::Left(std::iter::once(item)),
             OneOrMany::Many(items) => Either::Right(items.iter_mut()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extend_appends_the_right_side_after_the_left() {
+        assert_eq!(
+            OneOrMany::One(1).extend([2, 3]),
+            OneOrMany::Many(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OneOrMany::Many(vec![1, 2]).extend([3]),
+            OneOrMany::Many(vec![1, 2, 3])
+        );
+        assert_eq!(
+            OneOrMany::Many(vec![1, 2]).extend([3, 4]),
+            OneOrMany::Many(vec![1, 2, 3, 4])
+        );
+        assert_eq!(OneOrMany::One(1).extend([2]), OneOrMany::Many(vec![1, 2]));
+    }
+
+    #[test]
+    fn extend_with_nothing_leaves_the_left_side_untouched() {
+        assert_eq!(OneOrMany::One(1).extend([]), OneOrMany::One(1));
+        assert_eq!(
+            OneOrMany::Many(vec![1, 2]).extend([]),
+            OneOrMany::Many(vec![1, 2])
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot create OneOrMany from empty Vec")]
+    fn from_an_empty_vec_panics_where_from_iter_answers_with_an_empty_many() {
+        // The two doors into the type disagree, and only the from_iter side was
+        // pinned. Both are now held still while which one is right is undecided.
+        let _ = OneOrMany::<u8>::from(Vec::new());
+    }
+
+    #[test]
+    fn extend_leaves_an_empty_many_on_the_left_where_it_found_it() {
+        // {"Many":[]} arrives by deserialisation, and extend does not normalise
+        // it away. The derived PartialEq, Ord and Hash all read the variant, so
+        // Many([1]) and One(1) are different values.
+        assert_eq!(
+            OneOrMany::Many(Vec::new()).extend([1]),
+            OneOrMany::Many(vec![1])
+        );
+        assert_ne!(OneOrMany::Many(vec![1]), OneOrMany::One(1));
+    }
+
+    #[test]
+    fn extend_sizes_correctly_when_the_iterator_under_reports() {
+        // Every other test feeds an ExactSizeIterator. A filter reports a lower
+        // bound of zero, so the Vec cannot be sized from the hint alone.
+        let under_reporting = vec![2, 3].into_iter().filter(|_| true);
+
+        assert_eq!(
+            OneOrMany::One(1).extend(under_reporting),
+            OneOrMany::Many(vec![1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn extend_stepwise_matches_extend_at_once() {
+        let stepwise = OneOrMany::One(1).extend([2]).extend([3]);
+        let at_once = OneOrMany::One(1).extend([2, 3]);
+
+        assert_eq!(stepwise, at_once);
+        assert_eq!(stepwise.into_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn extend_buys_one_vec_of_the_size_it_needs() {
+        assert!(OneOrMany::One(1).extend([2]).into_vec().capacity() <= 2);
+        assert!(OneOrMany::One(1).extend([2, 3]).into_vec().capacity() <= 3);
+    }
+
+    #[test]
+    fn a_single_item_round_trips_through_the_iterator() {
+        let one = OneOrMany::One(1);
+
+        assert_eq!(one.len(), 1);
+        assert!(one.is_one());
+        assert_eq!(one.as_ref(), &[1]);
+        assert_eq!(one.into_iter().collect::<Vec<_>>(), vec![1]);
     }
 }

--- a/barter/src/engine/action/send_requests.rs
+++ b/barter/src/engine/action/send_requests.rs
@@ -190,3 +190,84 @@ impl<ExchangeKey, InstrumentKey, Kind> Default
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use barter_execution::order::{
+        OrderKey, OrderKind, TimeInForce,
+        id::{ClientOrderId, StrategyId},
+    };
+    use barter_instrument::Side;
+    use rust_decimal::Decimal;
+
+    fn key() -> OrderKey<ExchangeIndex, InstrumentIndex> {
+        OrderKey::new(
+            ExchangeIndex(0),
+            InstrumentIndex(0),
+            StrategyId::unknown(),
+            ClientOrderId::default(),
+        )
+    }
+
+    fn unrecoverable(reason: &str) -> EngineError {
+        EngineError::Unrecoverable(UnrecoverableEngineError::Custom(reason.to_string()))
+    }
+
+    fn cancels_failing(reasons: [&str; 1]) -> SendRequestsOutput<RequestCancel> {
+        SendRequestsOutput::new(
+            NoneOneOrMany::None,
+            reasons
+                .into_iter()
+                .map(|reason| {
+                    (
+                        OrderEvent::new(key(), RequestCancel::default()),
+                        unrecoverable(reason),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn opens_failing(reasons: [&str; 2]) -> SendRequestsOutput<RequestOpen> {
+        let request = RequestOpen::new(
+            Side::Buy,
+            Decimal::ONE,
+            Decimal::ONE,
+            OrderKind::Market,
+            TimeInForce::GoodUntilCancelled { post_only: false },
+        );
+
+        SendRequestsOutput::new(
+            NoneOneOrMany::None,
+            reasons
+                .into_iter()
+                .map(|reason| {
+                    (
+                        OrderEvent::new(key(), request.clone()),
+                        unrecoverable(reason),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn unrecoverable_errors_reports_the_cancel_failure_before_the_open_failures() {
+        // One cancel error and two open errors is the One-left / Many-right
+        // window, the only shape in which extend used to reverse its arguments.
+        let output = SendCancelsAndOpensOutput::new(
+            cancels_failing(["cancel failed"]),
+            opens_failing(["first open failed", "second open failed"]),
+        );
+
+        assert_eq!(
+            output.unrecoverable_errors().into_vec(),
+            vec![
+                UnrecoverableEngineError::Custom("cancel failed".to_string()),
+                UnrecoverableEngineError::Custom("first open failed".to_string()),
+                UnrecoverableEngineError::Custom("second open failed".to_string()),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
`OneOrMany::extend` and `NoneOneOrMany::extend` put the left side last whenever the left was `One` and the right yielded two or more items — `One(1).extend([2, 3])` returned `Many([2, 3, 1])`. `EngineAudit::add_errors` and `SendCancelsAndOpensOutput::unrecoverable_errors` both sit on that path, so the first thing to go wrong was reported last.

**Breaking.** `One(x).extend(nothing)` now returns `One(x)` where it returned `Many([x])`, so it serialises `{"One":x}` rather than `{"Many":[x]}`. Nothing in this workspace calls `OneOrMany::extend` — the break reaches dependents deserialising the audit stream. `NoneOneOrMany` is unaffected.

Second commit: collecting exactly one item no longer buys a `Vec`, and `extend` sizes its `Vec` once instead of growing into it. Counted with a global allocator: `One + One` 2→1, `One + nothing` 1→0, `from_iter` of one item 1→0.

19 tests where the two enum files carried none. Eight fail against the previous implementation, as does the new regression test at the `send_requests` caller.
