### PR TITLE
ci: release bump PRs open via the barter-release-bot app

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -61,12 +61,22 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # The default GITHUB_TOKEN may not create pull requests (403), and PRs it
+      # creates would not trigger CI - so the bump PR is opened as the
+      # barter-release-bot GitHub App instead.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           # `fetch-depth: 0` is needed to clone all the git history, which is necessary to
           # determine the next version and build the changelog.
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -75,6 +85,6 @@ jobs:
           # Run `release-plz release-pr` command.
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # In `release-plz-pr` this is only required if you are using a private registry.
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The `release-plz-pr` job has failed on every push to `main` it ever attempted: the default `GITHUB_TOKEN` is not permitted to create pull requests in this org (403). That is why no version-bump PR or changelog has ever appeared and the recent release cascade had to be bumped by hand.

This wires the job to a GitHub App token instead (`barter-release-bot` — installed on this repo only, Contents + Pull requests write): a `create-github-app-token` step mints a 1-hour token, and the job's checkout + release-plz steps use it. Two effects:

1. The 403 disappears — release-plz can open and force-update its bump PR.
2. Bump PRs are authored by the app, not the workflow token, so they **trigger Barter CI** like any human PR (default-token PRs never trigger workflows) and can be approved by a maintainer.

The `release-plz-release` job is untouched — it publishes fine on the default token.

Validation: merging this pushes to `main`, which re-runs the job; expect green with "nothing to release" (everything is published as of barter v0.13.0). The first real bump PR appears after the next crate-touching commit.