### PR TITLE
ci: app token step speaks v3 and identifies by client id

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -66,9 +66,9 @@ jobs:
       # barter-release-bot GitHub App instead.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLZ_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up polish to #289: `actions/create-github-app-token` v3 deprecates `app-id` in favour of `client-id`. The client id is not a secret, so it lives as the repo variable `RELEASE_PLZ_APP_CLIENT_ID` per the action's documented idiom (`private-key` stays a secret, unchanged). Also adds the file's missing trailing newline.

After merge the `RELEASE_PLZ_APP_ID` secret is unused and can be deleted.